### PR TITLE
Make Dentaku Ruby 1.8.7 compatible

### DIFF
--- a/lib/dentaku/evaluator.rb
+++ b/lib/dentaku/evaluator.rb
@@ -83,7 +83,8 @@ module Dentaku
     end
 
     def round(*args)
-      _, _, *tokens, _ = args
+      _, _, *tokens = args
+      tokens.pop
 
       input_tokens, places_tokens = tokens.chunk { |t| t.category == :grouping }.
                                           reject { |flag, tokens| flag }.
@@ -98,7 +99,8 @@ module Dentaku
     end
 
     def round_int(*args)
-      function, _, *tokens, _ = args
+      function, _, *tokens = args
+      tokens.pop
 
       value = evaluate_token_stream(tokens).value
       rounded = if function.value == :roundup


### PR DESCRIPTION
Ah, Ruby 1.8.7 - it doesn't allow splats to be non-terminal in an assignment list, so the array destructuring in the round methods doesn't work. 

To make Dentaku Ruby 1.8.7 compatible, I've made the code slightly uglier, but I couldn't think of a better way to do it right now.
