### PR TITLE
Performance tweaks for formula evaluation

### DIFF
--- a/lib/dentaku/evaluator.rb
+++ b/lib/dentaku/evaluator.rb
@@ -45,8 +45,8 @@ module Dentaku
         matched = true
 
         pattern.each do |matcher|
-          match = matcher.match(token_stream, position + matches.length)
-          matched &&= match.matched?
+          _matched, match = matcher.match(token_stream, position + matches.length)
+          matched &&= _matched
           matches += match
         end
 

--- a/lib/dentaku/token_matcher.rb
+++ b/lib/dentaku/token_matcher.rb
@@ -7,8 +7,12 @@ module Dentaku
       @values     = [values].compact.flatten
       @invert     = false
 
+      @categories_hash = Hash[@categories.map { |cat| [cat, 1] }]
+      @values_hash = Hash[@values.map { |value| [value, 1] }]
+
       @min = 1
       @max = 1
+      @range = (@min..@max)
     end
 
     def invert
@@ -23,39 +27,40 @@ module Dentaku
 
     def match(token_stream, offset=0)
       matched_tokens = []
+      matched = false
 
       while self == token_stream[matched_tokens.length + offset] && matched_tokens.length < @max
         matched_tokens << token_stream[matched_tokens.length + offset]
       end
 
-      if (@min..@max).include? matched_tokens.length
-        def matched_tokens.matched?() true end
-      else
-        def matched_tokens.matched?() false end
+      if @range.cover?(matched_tokens.length)
+        matched = true
       end
 
-      matched_tokens
+      [matched, matched_tokens]
     end
 
     def star
       @min = 0
       @max = Float::INFINITY
+      @range = (@min..@max)
       self
     end
 
     def plus
       @max = Float::INFINITY
+      @range = (@min..@max)
       self
     end
 
     private
 
     def category_match(category)
-      @categories.empty? || @categories.include?(category)
+      @categories_hash.empty? || @categories_hash.key?(category)
     end
 
     def value_match(value)
-      @values.empty? || @values.include?(value)
+      @values.empty? || @values_hash.key?(value)
     end
 
     def self.numeric;        new(:numeric);                        end
@@ -93,4 +98,3 @@ module Dentaku
 
   end
 end
-

--- a/lib/dentaku/version.rb
+++ b/lib/dentaku/version.rb
@@ -1,3 +1,3 @@
 module Dentaku
-  VERSION = "1.0.0"
+  VERSION = "1.1.0"
 end

--- a/spec/token_matcher_spec.rb
+++ b/spec/token_matcher_spec.rb
@@ -60,14 +60,14 @@ describe Dentaku::TokenMatcher do
       let(:standard) { described_class.new(:numeric) }
 
       it 'matches zero or more occurrences in a token stream' do
-        substream = standard.match(stream)
-        expect(substream).to be_matched
+        matched, substream = standard.match(stream)
+        expect(matched).to be_truthy
         expect(substream.length).to eq 1
         expect(substream.map(&:value)).to eq [5]
 
-        substream = standard.match(stream, 4)
+        matched, substream = standard.match(stream, 4)
         expect(substream).to be_empty
-        expect(substream).not_to be_matched
+        expect(matched).not_to be_truthy
       end
     end
 
@@ -75,14 +75,14 @@ describe Dentaku::TokenMatcher do
       let(:star) { described_class.new(:numeric).star }
 
       it 'matches zero or more occurrences in a token stream' do
-        substream = star.match(stream)
-        expect(substream).to be_matched
+        matched, substream = star.match(stream)
+        expect(matched).to be_truthy
         expect(substream.length).to eq 4
         expect(substream.map(&:value)).to eq [5, 11, 9, 24]
 
-        substream = star.match(stream, 4)
+        matched, substream = star.match(stream, 4)
         expect(substream).to be_empty
-        expect(substream).to be_matched
+        expect(matched).to be_truthy
       end
     end
 
@@ -90,14 +90,14 @@ describe Dentaku::TokenMatcher do
       let(:plus) { described_class.new(:numeric).plus }
 
       it 'matches one or more occurrences in a token stream' do
-        substream = plus.match(stream)
-        expect(substream).to be_matched
+        matched, substream = plus.match(stream)
+        expect(matched).to be_truthy
         expect(substream.length).to eq 4
         expect(substream.map(&:value)).to eq [5, 11, 9, 24]
 
-        substream = plus.match(stream, 4)
+        matched, substream = plus.match(stream, 4)
         expect(substream).to be_empty
-        expect(substream).not_to be_matched
+        expect(matched).not_to be_truthy
       end
     end
   end


### PR DESCRIPTION
We've been using Dentaku to perform some dynamic calculations on data points on an internal project. We pulled in the Ruby math functions but it ran slowly depending the complexity of the formula. I ran it through rubyprof to look at what was taking the most time and applied some tweaks:

Before:

```
Measuring Calculator Performance
                 user     system      total        real
method.call 10.910000   0.190000  11.100000 ( 11.097406)
method.send 17.830000   0.240000  18.070000 ( 18.077954)
```

After:

```
Measuring Calculator Performance
                 user     system      total        real
method.call  3.230000   0.000000   3.230000 (  3.228235)
method.send  5.250000   0.010000   5.260000 (  5.258325)
```

You can run the performance test using this code here: https://gist.github.com/jmangs/cee6dc95811200623551#file-perf-rb
