### PR TITLE
Return the unbound variables when evaluating invalid expression

### DIFF
--- a/lib/dentaku.rb
+++ b/lib/dentaku.rb
@@ -8,6 +8,11 @@ module Dentaku
   end
 
   class UnboundVariableError < StandardError
+    attr_reader :unbound_variables
+
+    def initialize(unbound_variables)
+      @unbound_variables = unbound_variables
+    end
   end
 
   private

--- a/lib/dentaku/calculator.rb
+++ b/lib/dentaku/calculator.rb
@@ -30,7 +30,7 @@ module Dentaku
     def evaluate!(expression, data={})
       store(data) do
         expr = Expression.new(expression, @memory)
-        raise UnboundVariableError if expr.unbound?
+        raise UnboundVariableError.new(expr.identifiers) if expr.unbound?
         @evaluator ||= Evaluator.new
         @result = @evaluator.evaluate(expr.tokens)
       end

--- a/spec/calculator_spec.rb
+++ b/spec/calculator_spec.rb
@@ -27,6 +27,9 @@ describe Dentaku::Calculator do
   it 'fails to evaluate unbound statements' do
     unbound = 'foo * 1.5'
     expect { calculator.evaluate!(unbound) }.to raise_error(Dentaku::UnboundVariableError)
+    expect { calculator.evaluate!(unbound) }.to raise_error do |error|
+      expect(error.unbound_variables).to eq [:foo]
+    end
     expect(calculator.evaluate(unbound)).to be_nil
     expect(calculator.evaluate(unbound) { :bar }).to eq :bar
     expect(calculator.evaluate(unbound) { |e| e }).to eq unbound


### PR DESCRIPTION
This pull request is a follow-up to issue #16. The UnboundVariableError exception now has a unbound_variables method containing an array with the remaining identifiers:

```
begin
  Dentaku::Calculator.new.evaluate!("foo / bar", { foo: nil })
rescue => e
  p e.unbound_variables
end

=> [:foo, :bar]
```

It also treats nil values as unbound variables (avoiding errors like `NoMethodError: undefined method `/' for nil:NilClass`), and makes UnboundVariableError inherit from StandardError instead of Exception.

Thank you for your library! :)
