### PR TITLE
find_rule_match breaks loop when no match

### DIFF
--- a/lib/dentaku/evaluator.rb
+++ b/lib/dentaku/evaluator.rb
@@ -47,6 +47,7 @@ module Dentaku
         pattern.each do |matcher|
           _matched, match = matcher.match(token_stream, position + matches.length)
           matched &&= _matched
+          break unless matched
           matches += match
         end
 


### PR DESCRIPTION
I was experiencing performance problems stemming from Dentaku with ~90 evaluates per page call with about a dozen added methods. This change resulted in a 4X speed improvement according to profiling my dev environment.

This change allows find_rule_match to break out of it's tightly looped
find_rule_match once it's become clear that no match is possible.
