### PR TITLE
Fix recognition of unary minus operator.

### DIFF
--- a/lib/dentaku/token_scanner.rb
+++ b/lib/dentaku/token_scanner.rb
@@ -42,7 +42,7 @@ module Dentaku
       end
 
       def numeric
-        new(:numeric, '(\d+(\.\d+)?|\.\d+)\b', lambda { |raw| raw =~ /\./ ? BigDecimal.new(raw) : raw.to_i })
+        new(:numeric, '-?(\d+(\.\d+)?|\.\d+)\b', lambda { |raw| raw =~ /\./ ? BigDecimal.new(raw) : raw.to_i })
       end
 
       def double_quoted_string

--- a/spec/tokenizer_spec.rb
+++ b/spec/tokenizer_spec.rb
@@ -67,6 +67,24 @@ describe Dentaku::Tokenizer do
     expect(tokens.map(&:value)).to eq(['animal', :eq, 'giraffe'])
   end
 
+  it 'recognizes binary minus operator' do
+    tokens = tokenizer.tokenize('2 - 3')
+    expect(tokens.map(&:category)).to eq([:numeric, :operator, :numeric])
+    expect(tokens.map(&:value)).to eq([2, :subtract, 3])
+  end
+
+  it 'recognizes unary minus operator' do
+    tokens = tokenizer.tokenize('-2 + 3')
+    expect(tokens.map(&:category)).to eq([:numeric, :operator, :numeric])
+    expect(tokens.map(&:value)).to eq([-2, :add, 3])
+  end
+
+  it 'recognizes unary minus operator' do
+    tokens = tokenizer.tokenize('2 - -3')
+    expect(tokens.map(&:category)).to eq([:numeric, :operator, :numeric])
+    expect(tokens.map(&:value)).to eq([2, :subtract, -3])
+  end
+
   it 'matches "<=" before "<"' do
     tokens = tokenizer.tokenize('perimeter <= 7500')
     expect(tokens.map(&:category)).to eq([:identifier, :comparator, :numeric])


### PR DESCRIPTION
Current behavior does not correctly apply precedence to the unary minus operator:

```
c = Dentaku::Calculator.new
c.evaluate('-4 + 3')
#=> -7
```

Added an optional minus before numeric tokens as well as specs to confirm.
