### PR TITLE
Correct error parsing unary minus.

### DIFF
--- a/lib/dentaku/evaluator.rb
+++ b/lib/dentaku/evaluator.rb
@@ -93,8 +93,12 @@ module Dentaku
       Token.new(*operation.send(operator.value))
     end
 
-    def negate(_, token)
-      Token.new(token.category, token.value * -1)
+    def negate(negop, _, token)
+      if negop.value == :start
+        Token.new(token.category, token.value * -1)
+      else
+        [negop, Token.new(token.category, token.value * -1)]
+      end
     end
 
     def percentage(token, _)

--- a/lib/dentaku/rules.rb
+++ b/lib/dentaku/rules.rb
@@ -12,13 +12,13 @@ module Dentaku
         [ p(:rounddown),  :round_int      ],
         [ p(:not),        :not            ],
 
+        [ p(:negation),   :negate         ],
         [ p(:group),      :evaluate_group ],
         [ p(:math_pow),   :apply          ],
         [ p(:math_mod),   :apply          ],
         [ p(:math_mul),   :apply          ],
         [ p(:math_add),   :apply          ],
         [ p(:percentage), :percentage     ],
-        [ p(:negation),   :negate         ],
         [ p(:range_asc),  :expand_range   ],
         [ p(:range_desc), :expand_range   ],
         [ p(:num_comp),   :apply          ],
@@ -63,7 +63,7 @@ module Dentaku
 
     def self.generate_matchers
       [
-        :numeric, :string, :addsub, :subtract, :muldiv, :pow, :mod,
+        :numeric, :string, :addsub, :subtract, :muldiv, :negop, :pow, :mod,
         :comparator, :comp_gt, :comp_lt, :fopen, :open, :close, :comma,
         :non_close_plus, :non_group, :non_group_star, :arguments,
         :logical, :combinator, :if, :round, :roundup, :rounddown, :not
@@ -79,7 +79,7 @@ module Dentaku
         math_mul:   pattern(:numeric,  :muldiv,         :numeric),
         math_pow:   pattern(:numeric,  :pow,            :numeric),
         math_mod:   pattern(:numeric,  :mod,            :numeric),
-        negation:   pattern(:subtract, :numeric),
+        negation:   pattern(:negop,    :subtract,       :numeric),
         percentage: pattern(:numeric,  :mod),
         range_asc:  pattern(:numeric,  :comp_lt,        :numeric,  :comp_lt, :numeric),
         range_desc: pattern(:numeric,  :comp_gt,        :numeric,  :comp_gt, :numeric),

--- a/lib/dentaku/token_matcher.rb
+++ b/lib/dentaku/token_matcher.rb
@@ -93,6 +93,15 @@ module Dentaku
 
     def self.addsub;         new(:operator, [:add, :subtract]);    end
     def self.subtract;       new(:operator, :subtract);            end
+    def self.negop;          new([:operator, :comparator, 
+                                  :grouping, :function, 
+                                  :logical, :combinator], 
+                                 [:add, :subtract, :multiply, 
+                                  :divide, :mod, :pow, :gt, :ge,
+                                  :lt, :le, :eq, :fopen, :open, 
+                                  :comma, :if, :round, :roundup, 
+                                  :rounddown, :not, :start, :and, 
+                                  :or]);                           end
     def self.muldiv;         new(:operator, [:multiply, :divide]); end
     def self.pow;            new(:operator, :pow);                 end
     def self.mod;            new(:operator, :mod);                 end

--- a/lib/dentaku/token_scanner.rb
+++ b/lib/dentaku/token_scanner.rb
@@ -42,7 +42,7 @@ module Dentaku
       end
 
       def numeric
-        new(:numeric, '-?(\d+(\.\d+)?|\.\d+)\b', lambda { |raw| raw =~ /\./ ? BigDecimal.new(raw) : raw.to_i })
+        new(:numeric, '(\d+(\.\d+)?|\.\d+)\b', lambda { |raw| raw =~ /\./ ? BigDecimal.new(raw) : raw.to_i })
       end
 
       def double_quoted_string

--- a/lib/dentaku/tokenizer.rb
+++ b/lib/dentaku/tokenizer.rb
@@ -6,6 +6,7 @@ module Dentaku
   class Tokenizer
     LPAREN = TokenMatcher.new(:grouping, [:open, :fopen])
     RPAREN = TokenMatcher.new(:grouping, :close)
+    SBTRCT = TokenMatcher.new(:operator, :subtract)
 
     def tokenize(string)
       @nesting = 0
@@ -20,6 +21,8 @@ module Dentaku
       end
 
       raise "too many opening parentheses" if @nesting > 0
+
+      @tokens = @tokens.unshift(Token.new(:operator, :start)) if !@tokens.empty? && SBTRCT == @tokens.first
 
       @tokens
     end

--- a/spec/calculator_spec.rb
+++ b/spec/calculator_spec.rb
@@ -4,8 +4,24 @@ describe Dentaku::Calculator do
   let(:calculator)  { described_class.new }
   let(:with_memory) { described_class.new.store(:apples => 3) }
 
-  it 'evaluates an expression' do
-    expect(calculator.evaluate('7+3')).to eq(10)
+  describe 'calculate' do
+    it 'evaluates an expression' do
+      expect(calculator.evaluate('7+3')).to eq(10)
+    end
+
+    it 'evaluates expressions with negative numbers' do
+      expect(calculator.evaluate('-1 + 2')).to eq(1)
+      expect(calculator.evaluate('1 - 2')).to eq(-1)
+      expect(calculator.evaluate('1 - - 2')).to eq(3)
+      expect(calculator.evaluate('-1 - - 2')).to eq(1)
+      expect(calculator.evaluate('1 - - - 2')).to eq(-1)
+      expect(calculator.evaluate('(-1 + 2)')).to eq(1)
+      expect(calculator.evaluate('-(1 + 2)')).to eq(-3)
+      expect(calculator.evaluate('2 ^ - 1')).to eq(0.5)
+      expect(calculator.evaluate('2 ^ -(3 - 2)')).to eq(0.5)
+      expect(calculator.evaluate('-num + 3', :num => 2)).to eq(1)
+      expect(calculator.evaluate('(2 + 3) - 1')).to eq(4)
+    end
   end
 
   describe 'memory' do
@@ -145,6 +161,13 @@ describe Dentaku::Calculator do
 
       expect(calculator.evaluate('NOT(some_boolean) AND 7 > 5', :some_boolean => true)).to be_falsey
       expect(calculator.evaluate('NOT(some_boolean) OR 7 < 5', :some_boolean => false)).to be_truthy
+    end
+
+    it 'evaluates functions with negative numbers' do
+      expect(calculator.evaluate('if (-1 < 5, -1, 5)')).to eq(-1)
+      expect(calculator.evaluate('if (-1 = -1, -1, 5)')).to eq(-1)
+      expect(calculator.evaluate('round(-1.23, 1)')).to eq(BigDecimal.new('-1.2'))
+      expect(calculator.evaluate('NOT(some_boolean) AND -1 > 3', :some_boolean => true)).to be_falsey
     end
   end
 end

--- a/spec/evaluator_spec.rb
+++ b/spec/evaluator_spec.rb
@@ -42,8 +42,10 @@ describe Dentaku::Evaluator do
     end
 
     it 'supports unary minus' do
-      expect(evaluator.evaluate(token_stream(:subtract, 1))).to eq(-1)
+      expect(evaluator.evaluate(token_stream(:start, :subtract, 1))).to eq(-1)
       expect(evaluator.evaluate(token_stream(1, :subtract, :subtract, 1))).to eq(2)
+      expect(evaluator.evaluate(token_stream(1, :subtract, :subtract, :subtract, 1))).to eq(0)
+      expect(evaluator.evaluate(token_stream(:start, :subtract, 1, :add, 1))).to eq(0)
     end
 
     it 'supports unary percentage' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,7 +15,7 @@ def type_for(value)
     :string
   when true, false
     :logical
-  when :add, :subtract, :multiply, :divide, :mod
+  when :add, :subtract, :multiply, :divide, :mod, :start
     :operator
   when :fopen, :open, :close, :comma
     :grouping

--- a/spec/tokenizer_spec.rb
+++ b/spec/tokenizer_spec.rb
@@ -67,24 +67,6 @@ describe Dentaku::Tokenizer do
     expect(tokens.map(&:value)).to eq(['animal', :eq, 'giraffe'])
   end
 
-  it 'recognizes binary minus operator' do
-    tokens = tokenizer.tokenize('2 - 3')
-    expect(tokens.map(&:category)).to eq([:numeric, :operator, :numeric])
-    expect(tokens.map(&:value)).to eq([2, :subtract, 3])
-  end
-
-  it 'recognizes unary minus operator' do
-    tokens = tokenizer.tokenize('-2 + 3')
-    expect(tokens.map(&:category)).to eq([:numeric, :operator, :numeric])
-    expect(tokens.map(&:value)).to eq([-2, :add, 3])
-  end
-
-  it 'recognizes unary minus operator' do
-    tokens = tokenizer.tokenize('2 - -3')
-    expect(tokens.map(&:category)).to eq([:numeric, :operator, :numeric])
-    expect(tokens.map(&:value)).to eq([2, :subtract, -3])
-  end
-
   it 'matches "<=" before "<"' do
     tokens = tokenizer.tokenize('perimeter <= 7500')
     expect(tokens.map(&:category)).to eq([:identifier, :comparator, :numeric])


### PR DESCRIPTION
- Revert regex to not include minus sign
- Make negation the highest-priority operation
- Only permit negation in proper context
