### PR TITLE
Fix evaluation of negative exponents.

### DIFF
--- a/lib/dentaku/evaluator.rb
+++ b/lib/dentaku/evaluator.rb
@@ -98,6 +98,10 @@ module Dentaku
       Token.new(token.category, token.value * -1)
     end
 
+    def pow_negate(base, _, _, exp)
+      Token.new(base.category, base.value ** (exp.value * -1))
+    end
+
     def percentage(token, _)
       Token.new(token.category, token.value / 100.0)
     end

--- a/lib/dentaku/rules.rb
+++ b/lib/dentaku/rules.rb
@@ -6,25 +6,26 @@ module Dentaku
   class Rules
     def self.core_rules
       [
-        [ p(:if),         :if             ],
-        [ p(:round),      :round          ],
-        [ p(:roundup),    :round_int      ],
-        [ p(:rounddown),  :round_int      ],
-        [ p(:not),        :not            ],
+        [ p(:if),           :if             ],
+        [ p(:round),        :round          ],
+        [ p(:roundup),      :round_int      ],
+        [ p(:rounddown),    :round_int      ],
+        [ p(:not),          :not            ],
 
-        [ p(:group),      :evaluate_group ],
-        [ p(:start_neg),  :negate         ],
-        [ p(:math_pow),   :apply          ],
-        [ p(:math_mod),   :apply          ],
-        [ p(:math_mul),   :apply          ],
-        [ p(:math_add),   :apply          ],
-        [ p(:percentage), :percentage     ],
-        [ p(:negation),   :negate         ],
-        [ p(:range_asc),  :expand_range   ],
-        [ p(:range_desc), :expand_range   ],
-        [ p(:num_comp),   :apply          ],
-        [ p(:str_comp),   :apply          ],
-        [ p(:combine),    :apply          ]
+        [ p(:group),        :evaluate_group ],
+        [ p(:start_neg),    :negate         ],
+        [ p(:math_pow),     :apply          ],
+        [ p(:math_neg_pow), :pow_negate     ],
+        [ p(:math_mod),     :apply          ],
+        [ p(:math_mul),     :apply          ],
+        [ p(:math_add),     :apply          ],
+        [ p(:percentage),   :percentage     ],
+        [ p(:negation),     :negate         ],
+        [ p(:range_asc),    :expand_range   ],
+        [ p(:range_desc),   :expand_range   ],
+        [ p(:num_comp),     :apply          ],
+        [ p(:str_comp),     :apply          ],
+        [ p(:combine),      :apply          ]
       ]
     end
 
@@ -68,7 +69,7 @@ module Dentaku
         :comparator, :comp_gt, :comp_lt, :fopen, :open, :close, :comma,
         :non_close_plus, :non_group, :non_group_star, :arguments,
         :logical, :combinator, :if, :round, :roundup, :rounddown, :not,
-        :anchored_minus
+        :anchored_minus, :math_neg_pow
       ].each_with_object({}) do |name, matchers|
         matchers[name] = TokenMatcher.send(name)
       end
@@ -76,25 +77,26 @@ module Dentaku
 
     def self.p(name)
       @patterns ||= {
-        group:      pattern(:open,     :non_group_star, :close),
-        math_add:   pattern(:numeric,  :addsub,         :numeric),
-        math_mul:   pattern(:numeric,  :muldiv,         :numeric),
-        math_pow:   pattern(:numeric,  :pow,            :numeric),
-        math_mod:   pattern(:numeric,  :mod,            :numeric),
-        negation:   pattern(:subtract, :numeric),
-        start_neg:  pattern(:anchored_minus, :numeric),
-        percentage: pattern(:numeric,  :mod),
-        range_asc:  pattern(:numeric,  :comp_lt,        :numeric,  :comp_lt, :numeric),
-        range_desc: pattern(:numeric,  :comp_gt,        :numeric,  :comp_gt, :numeric),
-        num_comp:   pattern(:numeric,  :comparator,     :numeric),
-        str_comp:   pattern(:string,   :comparator,     :string),
-        combine:    pattern(:logical,  :combinator,     :logical),
+        group:        pattern(:open,     :non_group_star, :close),
+        math_add:     pattern(:numeric,  :addsub,         :numeric),
+        math_mul:     pattern(:numeric,  :muldiv,         :numeric),
+        math_pow:     pattern(:numeric,  :pow,            :numeric),
+        math_neg_pow: pattern(:numeric,  :pow,            :subtract, :numeric),
+        math_mod:     pattern(:numeric,  :mod,            :numeric),
+        negation:     pattern(:subtract, :numeric),
+        start_neg:    pattern(:anchored_minus, :numeric),
+        percentage:   pattern(:numeric,  :mod),
+        range_asc:    pattern(:numeric,  :comp_lt,        :numeric,  :comp_lt, :numeric),
+        range_desc:   pattern(:numeric,  :comp_gt,        :numeric,  :comp_gt, :numeric),
+        num_comp:     pattern(:numeric,  :comparator,     :numeric),
+        str_comp:     pattern(:string,   :comparator,     :string),
+        combine:      pattern(:logical,  :combinator,     :logical),
 
-        if:         func_pattern(:if,        :non_group,      :comma, :non_group, :comma, :non_group),
-        round:      func_pattern(:round,     :arguments),
-        roundup:    func_pattern(:roundup,   :arguments),
-        rounddown:  func_pattern(:rounddown, :arguments),
-        not:        func_pattern(:not,       :arguments)
+        if:           func_pattern(:if,        :non_group,      :comma, :non_group, :comma, :non_group),
+        round:        func_pattern(:round,     :arguments),
+        roundup:      func_pattern(:roundup,   :arguments),
+        rounddown:    func_pattern(:rounddown, :arguments),
+        not:          func_pattern(:not,       :arguments)
       }
 
       @patterns[name]

--- a/spec/calculator_spec.rb
+++ b/spec/calculator_spec.rb
@@ -22,6 +22,8 @@ describe Dentaku::Calculator do
     expect(calculator.evaluate('1 + -2 ^ 2')).to eq(-3)
     expect(calculator.evaluate('3 + -num', :num => 2)).to eq(1)
     expect(calculator.evaluate('-num + 3', :num => 2)).to eq(1)
+    expect(calculator.evaluate('10 ^ 2')).to eq(100)
+    expect(calculator.evaluate('0 * 10 ^ -5')).to eq(0)
   end
 
   describe 'memory' do

--- a/spec/evaluator_spec.rb
+++ b/spec/evaluator_spec.rb
@@ -48,6 +48,12 @@ describe Dentaku::Evaluator do
       expect(evaluator.evaluate(token_stream(:subtract, 1, :add, 1))).to eq(0)
     end
 
+    it 'evaluates a number multiplied by an exponent' do
+      expect(evaluator.evaluate(token_stream(10, :pow, 2))).to eq(100)
+      expect(evaluator.evaluate(token_stream(0, :multiply, 10, :pow, 5))).to eq(0)
+      expect(evaluator.evaluate(token_stream(0, :multiply, 10, :pow, :subtract, 5))).to eq(0)
+    end
+
     it 'supports unary percentage' do
       expect(evaluator.evaluate(token_stream(50, :mod))).to eq(0.5)
       expect(evaluator.evaluate(token_stream(50, :mod, :multiply, 100))).to eq(50)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,7 +15,7 @@ def type_for(value)
     :string
   when true, false
     :logical
-  when :add, :subtract, :multiply, :divide, :mod
+  when :add, :subtract, :multiply, :divide, :mod, :pow
     :operator
   when :fopen, :open, :close, :comma
     :grouping

--- a/spec/tokenizer_spec.rb
+++ b/spec/tokenizer_spec.rb
@@ -37,6 +37,18 @@ describe Dentaku::Tokenizer do
     expect(tokens.map(&:value)).to eq([1, :divide, 1])
   end
 
+  it 'tokenizes power operations' do
+    tokens = tokenizer.tokenize('10 ^ 2')
+    expect(tokens.map(&:category)).to eq([:numeric, :operator, :numeric])
+    expect(tokens.map(&:value)).to eq([10, :pow, 2])
+  end
+
+  it 'tokenizes power operations' do
+    tokens = tokenizer.tokenize('0 * 10 ^ -5')
+    expect(tokens.map(&:category)).to eq([:numeric, :operator, :numeric, :operator, :operator, :numeric])
+    expect(tokens.map(&:value)).to eq([0, :multiply, 10, :pow, :subtract, 5])
+  end
+
   it 'handles floating point' do
     tokens = tokenizer.tokenize('1.5 * 3.7')
     expect(tokens.map(&:category)).to eq([:numeric, :operator, :numeric])


### PR DESCRIPTION
I found another issue related to unary minus:

```
Dentaku.evaluate('0 * 10 ^ -2')
#=> ZeroDivisionError: divided by 0
```

The problem is that the `:pow` operation only matches `:numeric, :pow, :numeric` when it should also match negative exponents, i.e. `:numeric, :pow, :subtract, :numeric`. As a result, the multiplication is evaluated first, then `0 ^ -2` is evaluated- this is `1 / (0 ** 2)` and produces the divide by zero error.

I solved it by adding a `:math_neg_pow` to match `:numeric, :pow, :subtract, :numeric` and evaluate negative exponents. Feel free to implement a different solution if you have a cleaner way to handle it :smile: 
