### PR TITLE
Correctly bind unary minus on multiplication and division.

### DIFF
--- a/lib/dentaku/evaluator.rb
+++ b/lib/dentaku/evaluator.rb
@@ -102,6 +102,10 @@ module Dentaku
       Token.new(base.category, base.value ** (exp.value * -1))
     end
 
+    def pow_mul(val1, _, _, val2)
+      Token.new(val1.category, val1.value * val2.value * -1)
+    end
+
     def percentage(token, _)
       Token.new(token.category, token.value / 100.0)
     end

--- a/lib/dentaku/rules.rb
+++ b/lib/dentaku/rules.rb
@@ -18,6 +18,7 @@ module Dentaku
         [ p(:math_neg_pow), :pow_negate     ],
         [ p(:math_mod),     :apply          ],
         [ p(:math_mul),     :apply          ],
+        [ p(:math_neg_mul), :pow_mul        ],
         [ p(:math_add),     :apply          ],
         [ p(:percentage),   :percentage     ],
         [ p(:negation),     :negate         ],
@@ -69,7 +70,7 @@ module Dentaku
         :comparator, :comp_gt, :comp_lt, :fopen, :open, :close, :comma,
         :non_close_plus, :non_group, :non_group_star, :arguments,
         :logical, :combinator, :if, :round, :roundup, :rounddown, :not,
-        :anchored_minus, :math_neg_pow
+        :anchored_minus, :math_neg_pow, :math_neg_mul
       ].each_with_object({}) do |name, matchers|
         matchers[name] = TokenMatcher.send(name)
       end
@@ -80,6 +81,7 @@ module Dentaku
         group:        pattern(:open,     :non_group_star, :close),
         math_add:     pattern(:numeric,  :addsub,         :numeric),
         math_mul:     pattern(:numeric,  :muldiv,         :numeric),
+        math_neg_mul: pattern(:numeric,  :muldiv,         :subtract, :numeric),
         math_pow:     pattern(:numeric,  :pow,            :numeric),
         math_neg_pow: pattern(:numeric,  :pow,            :subtract, :numeric),
         math_mod:     pattern(:numeric,  :mod,            :numeric),

--- a/lib/dentaku/version.rb
+++ b/lib/dentaku/version.rb
@@ -1,3 +1,3 @@
 module Dentaku
-  VERSION = "1.2.3"
+  VERSION = "1.2.4"
 end

--- a/spec/calculator_spec.rb
+++ b/spec/calculator_spec.rb
@@ -24,6 +24,8 @@ describe Dentaku::Calculator do
     expect(calculator.evaluate('-num + 3', :num => 2)).to eq(1)
     expect(calculator.evaluate('10 ^ 2')).to eq(100)
     expect(calculator.evaluate('0 * 10 ^ -5')).to eq(0)
+    expect(calculator.evaluate('3 + 0 * -3')).to eq(3)
+    expect(calculator.evaluate('3 + 0 / -3')).to eq(3)
   end
 
   describe 'memory' do

--- a/spec/evaluator_spec.rb
+++ b/spec/evaluator_spec.rb
@@ -46,6 +46,7 @@ describe Dentaku::Evaluator do
       expect(evaluator.evaluate(token_stream(1, :subtract, :subtract, 1))).to eq(2)
       expect(evaluator.evaluate(token_stream(1, :subtract, :subtract, :subtract, 1))).to eq(0)
       expect(evaluator.evaluate(token_stream(:subtract, 1, :add, 1))).to eq(0)
+      expect(evaluator.evaluate(token_stream(3, :add, 0, :multiply, :subtract, 3))).to eq(3)
     end
 
     it 'evaluates a number multiplied by an exponent' do


### PR DESCRIPTION
Fixes this failing case: `Dentaku.evaluate("3 + 0 * -3") => -9`