### PR TITLE
Added smart filter for Rules to improve performance

### DIFF
--- a/lib/dentaku/calculator.rb
+++ b/lib/dentaku/calculator.rb
@@ -11,6 +11,7 @@ module Dentaku
 
     def initialize
       clear
+      Rules.refresh
     end
 
     def add_function(fn)

--- a/lib/dentaku/evaluator.rb
+++ b/lib/dentaku/evaluator.rb
@@ -24,7 +24,8 @@ module Dentaku
 
     def match_rule_pattern(tokens)
       matched = false
-      Rules.each do |pattern, evaluator|
+
+      Rules.filter(tokens).each do |pattern, evaluator|
         pos, match = find_rule_match(pattern, tokens)
 
         if pos

--- a/lib/dentaku/token_matcher.rb
+++ b/lib/dentaku/token_matcher.rb
@@ -2,7 +2,7 @@ require 'dentaku/token'
 
 module Dentaku
   class TokenMatcher
-    attr_reader :children
+    attr_reader :children, :categories, :values
 
     def initialize(categories=nil, values=nil, children=[])
       # store categories and values as hash to optimize key lookup, h/t @jan-mangs


### PR DESCRIPTION
When you start adding a lot of rules (new functions in my case) you start to see a degradation in performance:

Tested using this Gist: [perf.rb](https://gist.github.com/jmangs/cee6dc95811200623551)
I'm running about a sample of 2,000 runs to do calculations on random numbers.

The majority of the time was trying to do pattern matches on every single Rule available (which are expensive to do). Instead of operating on all rules, I've implemented a `filter` method on `Rules` that only returns the applicable rules for a given array of tokens. Since we don't care about raw numerical values I also zeroed out the raw numbers in the tokens when checking them - this allows the class to cache token patterns so if you do `5 + x / 2` and then `4 + x / 3` then it will not bother rediscovering compatible rules since it's already seen the pattern once before (doing intersections on arrays is expensive too).

Base 1.2.4:
```
bundle exec ruby perf.rb 
Measuring Calculator Performance
                   user     system      total        real
cos((x + y * 2))  4.380000   0.000000   4.380000 (  4.382882)
x + y * 2         3.070000   0.000000   3.070000 (  3.068845)
```

After Requested Change:
```
bundle exec ruby perf.rb 
Measuring Calculator Performance
                   user     system      total        real
cos((x + y * 2))  0.830000   0.000000   0.830000 (  0.833229)
x + y * 2         0.540000   0.000000   0.540000 (  0.541628)
```