### PR TITLE
Address solve behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ vendor/*
 
 /.ruby-gemset
 /.ruby-version
+/.rspec

--- a/.pryrc
+++ b/.pryrc
@@ -1,3 +1,2 @@
 require "bundler"
-require 'bundler'
 Bundler.require

--- a/.pryrc
+++ b/.pryrc
@@ -1,0 +1,3 @@
+require "bundler"
+require 'bundler'
+Bundler.require

--- a/dentaku.gemspec
+++ b/dentaku.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency('rake')
   s.add_development_dependency('rspec')
+  s.add_development_dependency('pry')
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/lib/dentaku/bulk_expression_solver.rb
+++ b/lib/dentaku/bulk_expression_solver.rb
@@ -1,0 +1,55 @@
+require 'dentaku/calculator'
+require 'dentaku/dependency_resolver'
+require 'dentaku/exceptions'
+require 'dentaku/expression'
+
+module Dentaku
+  class BulkExpressionSolver
+    def initialize(expression_hash, memory, calculator)
+      self.expression_hash = expression_hash
+      self.memory = memory
+      self.calculator = calculator
+    end
+
+    def solve!
+      results = load_results
+
+      expression_hash.each_with_object({}) do |(k, _), r|
+        r[k] = results[k.to_s]
+      end
+    end
+
+    private
+
+    attr_accessor :expression_hash, :memory, :calculator
+
+    def load_results
+      variables_in_resolve_order.each_with_object({}) do |var_name, r|
+        r[var_name] = evaluate!(expressions[var_name], r)
+      end
+    end
+
+    def dependencies(expression)
+      Expression.new(expression, memory).identifiers
+    end
+
+    def expressions
+      @expressions ||= Hash[expression_hash.map { |k,v| [k.to_s, v] }]
+    end
+
+    def expression_dependencies
+      Hash[expressions.map { |var, expr| [var, dependencies(expr)] }]
+    end
+
+    def variables_in_resolve_order
+      @variables_in_resolve_order ||=
+        DependencyResolver::find_resolve_order(expression_dependencies)
+    end
+
+    def evaluate!(expression, results)
+      expr = Expression.new(expression, memory.merge(expressions))
+      raise UnboundVariableError.new(expr.identifiers) if expr.unbound?
+      calculator.evaluate!(expression, results)
+    end
+  end
+end

--- a/lib/dentaku/calculator.rb
+++ b/lib/dentaku/calculator.rb
@@ -41,7 +41,11 @@ module Dentaku
     end
 
     def solve!(expression_hash)
-      BulkExpressionSolver.new(expression_hash, @memory, self).solve!
+      BulkExpressionSolver.new(expression_hash, @memory).solve!
+    end
+
+    def solve(expression_hash, &block)
+      BulkExpressionSolver.new(expression_hash, @memory).solve(&block)
     end
 
     def dependencies(expression)

--- a/lib/dentaku/calculator.rb
+++ b/lib/dentaku/calculator.rb
@@ -52,6 +52,8 @@ module Dentaku
         expression_dependencies)
 
       results = variables_in_resolve_order.each_with_object({}) do |var_name, r|
+        expr = Expression.new(expressions[var_name], @memory.merge(expressions))
+        raise UnboundVariableError.new(expr.identifiers) if expr.unbound?
         r[var_name] = evaluate!(expressions[var_name], r)
       end
 

--- a/lib/dentaku/calculator.rb
+++ b/lib/dentaku/calculator.rb
@@ -1,3 +1,4 @@
+require 'dentaku/bulk_expression_solver'
 require 'dentaku/evaluator'
 require 'dentaku/exceptions'
 require 'dentaku/expression'
@@ -40,26 +41,7 @@ module Dentaku
     end
 
     def solve!(expression_hash)
-      expressions = Hash[expression_hash.map { |k,v| [k.to_s, v] }]
-
-      # expression_hash: { variable_name: "string expression" }
-      # TSort thru the expressions' dependencies, then evaluate all
-      expression_dependencies = Hash[expressions.map do |var, expr|
-        [var, dependencies(expr)]
-      end]
-
-      variables_in_resolve_order = DependencyResolver::find_resolve_order(
-        expression_dependencies)
-
-      results = variables_in_resolve_order.each_with_object({}) do |var_name, r|
-        expr = Expression.new(expressions[var_name], @memory.merge(expressions))
-        raise UnboundVariableError.new(expr.identifiers) if expr.unbound?
-        r[var_name] = evaluate!(expressions[var_name], r)
-      end
-
-      expression_hash.each_with_object({}) do |(k, _), r|
-        r[k] = results[k.to_s]
-      end
+      BulkExpressionSolver.new(expression_hash, @memory, self).solve!
     end
 
     def dependencies(expression)

--- a/spec/bulk_expression_solver_spec.rb
+++ b/spec/bulk_expression_solver_spec.rb
@@ -1,0 +1,38 @@
+require 'dentaku/bulk_expression_solver'
+
+RSpec.describe Dentaku::BulkExpressionSolver do
+  describe "#solve!" do
+    it "evaluates properly with variables, even if some in memory" do
+      expressions = {
+        weekly_fruit_budget: "weekly_apple_budget + pear * 4",
+        weekly_apple_budget: "apples * 7",
+        pear: "1"
+      }
+      memory = {apples: 3}
+      solver = described_class.new(expressions, memory)
+      expect(solver.solve!)
+        .to eq(pear: 1, weekly_apple_budget: 21, weekly_fruit_budget: 25)
+    end
+
+    it "lets you know if a variable is unbound" do
+      expressions = {more_apples: "apples + 1"}
+      expect {
+        described_class.new(expressions, {}).solve!()
+      }.to raise_error(Dentaku::UnboundVariableError)
+    end
+  end
+
+  describe "#solve" do
+    it "returns :undefined when variables are unbound" do
+      expressions = {more_apples: "apples + 1"}
+      expect(described_class.new(expressions, {}).solve())
+        .to eq(more_apples: :undefined)
+    end
+
+    it "allows passing in a custom value to an error handler" do
+      expressions = {more_apples: "apples + 1"}
+      expect(described_class.new(expressions, {}).solve() { :foo })
+        .to eq(more_apples: :foo)
+    end
+  end
+end

--- a/spec/calculator_spec.rb
+++ b/spec/calculator_spec.rb
@@ -87,6 +87,12 @@ describe Dentaku::Calculator do
       result = with_memory.solve!(total_fruit: "Apples + pears", pears: 10)
       expect(result[:total_fruit]).to eq 13
     end
+
+    it "lets you know if a variable is unbound" do
+      expect {
+        calculator.solve!(more_apples: "apples + 1")
+      }.to raise_error(Dentaku::UnboundVariableError)
+    end
   end
 
   it 'evaluates a statement with no variables' do

--- a/spec/calculator_spec.rb
+++ b/spec/calculator_spec.rb
@@ -95,6 +95,19 @@ describe Dentaku::Calculator do
     end
   end
 
+  describe 'solve' do
+    it "returns :undefined when variables are unbound" do
+      expressions = {more_apples: "apples + 1"}
+      expect(calculator.solve(expressions)).to eq(more_apples: :undefined)
+    end
+
+    it "allows passing in a custom value to an error handler" do
+      expressions = {more_apples: "apples + 1"}
+      expect(calculator.solve(expressions) { :foo })
+        .to eq(more_apples: :foo)
+    end
+  end
+
   it 'evaluates a statement with no variables' do
     expect(calculator.evaluate('5+3')).to eq(8)
     expect(calculator.evaluate('(1+1+1)/3*100')).to eq(100)


### PR DESCRIPTION
@rubysolo I extracted a service object here because it seemed the cleanest way to isolate the `solve` and `solve!` methods. There is a little bit of coupling here with `memory` that I wasn't sure how best to address. I feel like I found a happy medium, but feel free to suggest a better alternative.

I also decided to return `:undefined` instead of `nil` by default, it seemed like a more honest response. Again, let me know if you would prefer an alternative here.

Also feel free to beat me up on style or naming, we are kind of unique at TeamSnap :)

fixes #47 