### PR TITLE
add divide by zero protection to `solve`

### DIFF
--- a/lib/dentaku/bulk_expression_solver.rb
+++ b/lib/dentaku/bulk_expression_solver.rb
@@ -39,7 +39,7 @@ module Dentaku
       variables_in_resolve_order.each_with_object({}) do |var_name, r|
         begin
           r[var_name] = evaluate!(expressions[var_name], r)
-        rescue Dentaku::UnboundVariableError => ex
+        rescue Dentaku::UnboundVariableError, ZeroDivisionError => ex
           r[var_name] = block.call(ex)
         end
       end

--- a/spec/bulk_expression_solver_spec.rb
+++ b/spec/bulk_expression_solver_spec.rb
@@ -20,6 +20,13 @@ RSpec.describe Dentaku::BulkExpressionSolver do
         described_class.new(expressions, {}).solve!()
       }.to raise_error(Dentaku::UnboundVariableError)
     end
+
+    it "lets you know if the result is a div/0 error" do
+      expressions = {more_apples: "1/0"}
+      expect {
+        described_class.new(expressions, {}).solve!()
+      }.to raise_error(ZeroDivisionError)
+    end
   end
 
   describe "#solve" do
@@ -29,8 +36,14 @@ RSpec.describe Dentaku::BulkExpressionSolver do
         .to eq(more_apples: :undefined)
     end
 
-    it "allows passing in a custom value to an error handler" do
+    it "allows passing in a custom value to an error handler when a variable is unbound" do
       expressions = {more_apples: "apples + 1"}
+      expect(described_class.new(expressions, {}).solve() { :foo })
+        .to eq(more_apples: :foo)
+    end
+
+    it "allows passing in a custom value to an error handler when there is a div/0 error" do
+      expressions = {more_apples: "1/0"}
       expect(described_class.new(expressions, {}).solve() { :foo })
         .to eq(more_apples: :foo)
     end


### PR DESCRIPTION
I only implemented this for `solve` let me know if you would like something similar for `evaluate`

Thanks again!

fixes #46 