### PR TITLE
add ability to comment within expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,28 @@ calc.solve!(
 #=> raises TSort::Cyclic
 ```
 
+INLINE COMMENTS
+---------------------------------
+
+If your expressions grow long or complex, you may add inline comments for future reference. This is particularly useful if you save your expressions in a model.
+
+```ruby
+calculator.evaluate('kiwi + 5 /* This is a comment */', kiwi: 2)
+#=> 7
+```
+
+Comments can be single or multi-line. The following are also valid.
+
+```
+/*
+ * This is a multi-line comment
+ */
+
+/*
+ This is another type of multi-line comment
+ */
+```
+
 EXTERNAL FUNCTIONS
 ------------------
 

--- a/lib/dentaku/tokenizer.rb
+++ b/lib/dentaku/tokenizer.rb
@@ -10,7 +10,7 @@ module Dentaku
     def tokenize(string)
       @nesting = 0
       @tokens  = []
-      input    = string.to_s.dup
+      input    = strip_comments(string.to_s.dup)
 
       until input.empty?
         raise "parse error at: '#{ input }'" unless TokenScanner.scanners.any? do |scanner|
@@ -41,6 +41,10 @@ module Dentaku
       else
         [false, string]
       end
+    end
+
+    def strip_comments(input)
+      input.gsub(/\/\*[^*]*\*+(?:[^*\/][^*]*\*+)*\//, '')
     end
   end
 end


### PR DESCRIPTION
As discussed on Gitter, it would be great to add inline comments to expressions. This is particularly useful if expressions are saved to the database and they begin to get long, complex or unwieldy.

Here's an example (also added to the README):

```ruby
calculator.evaluate('kiwi + 5 /* This is a comment */', kiwi: 2)
#=> 7
```

Comments can be single or multi-line. The following are also valid.

```javascript
/*
 * This is a multi-line comment
 */

/*
 This is another type of multi-line comment
 */
```

Rikki