### PR TITLE
Added support for Math functions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ Logic: `< > <= >= <> != = AND OR`
 
 Functions: `IF NOT ROUND ROUNDDOWN ROUNDUP`
 
+Math: all functions from Ruby's Math module, including `SIN, COS, TAN, ...`
+
 RESOLVING DEPENDENCIES
 ----------------------
 

--- a/lib/dentaku/evaluator.rb
+++ b/lib/dentaku/evaluator.rb
@@ -1,8 +1,10 @@
 require 'dentaku/rule_set'
 require 'dentaku/binary_operation'
+require 'dentaku/math'
 
 module Dentaku
   class Evaluator
+    include Dentaku::Math
     attr_reader :rule_set
 
     def initialize(rule_set)

--- a/lib/dentaku/math.rb
+++ b/lib/dentaku/math.rb
@@ -1,0 +1,40 @@
+require 'dentaku/token_matchers'
+
+module Dentaku
+  module Math
+    def self.exported_methods
+      ::Math.methods(false)
+    end
+
+    def self.rules
+      Math.exported_methods.map do |method|
+        [pattern(method), method]
+      end
+    end
+
+    def self.patterns
+      @patterns ||= Hash[Math.exported_methods.map { |method|
+        [method, TokenMatchers.function_token_matchers(method, :arguments)]
+      }]
+    end
+
+    def self.pattern(name)
+      Math.patterns[name]
+    end
+
+    def delegate_to_math(method, args)
+      ::Math.send(method, *args)
+    end
+
+    Math.exported_methods.each do |method|
+      define_method method do |*args|
+        function, _, *tokens, _ = *args
+        values = tokens.map(&:value).select { |value| value.is_a?(Numeric) }
+        result = delegate_to_math method, values
+        Token.new(:numeric, result)
+      end
+    end
+
+    extend self
+  end
+end

--- a/lib/dentaku/rule_set.rb
+++ b/lib/dentaku/rule_set.rb
@@ -1,3 +1,4 @@
+require 'dentaku/token_matchers'
 require 'dentaku/external_function'
 
 module Dentaku
@@ -19,7 +20,7 @@ module Dentaku
       fn = ExternalFunction.new(function[:name], function[:type], function[:signature], function[:body])
 
       custom_rules.push [
-        function_token_matchers(fn.name, *fn.tokens),
+        TokenMatchers.function_token_matchers(fn.name, *fn.tokens),
         fn.name
       ]
 
@@ -93,45 +94,35 @@ module Dentaku
         [ pattern(:num_comp),     :apply          ],
         [ pattern(:str_comp),     :apply          ],
         [ pattern(:combine),      :apply          ]
-      ]
+      ].concat(Math.rules)
     end
 
     def pattern(name)
       @patterns ||= {
-        group:        token_matchers(:open,     :non_group_star, :close),
-        math_add:     token_matchers(:numeric,  :addsub,         :numeric),
-        math_mul:     token_matchers(:numeric,  :muldiv,         :numeric),
-        math_neg_mul: token_matchers(:numeric,  :muldiv,         :subtract, :numeric),
-        math_pow:     token_matchers(:numeric,  :pow,            :numeric),
-        math_neg_pow: token_matchers(:numeric,  :pow,            :subtract, :numeric),
-        math_mod:     token_matchers(:numeric,  :mod,            :numeric),
-        negation:     token_matchers(:subtract, :numeric),
-        start_neg:    token_matchers(:anchored_minus, :numeric),
-        percentage:   token_matchers(:numeric,  :mod),
-        range_asc:    token_matchers(:numeric,  :comp_lt,        :numeric,  :comp_lt, :numeric),
-        range_desc:   token_matchers(:numeric,  :comp_gt,        :numeric,  :comp_gt, :numeric),
-        num_comp:     token_matchers(:numeric,  :comparator,     :numeric),
-        str_comp:     token_matchers(:string,   :comparator,     :string),
-        combine:      token_matchers(:logical,  :combinator,     :logical),
+        group:        TokenMatchers.token_matchers(:open,     :non_group_star, :close),
+        math_add:     TokenMatchers.token_matchers(:numeric,  :addsub,         :numeric),
+        math_mul:     TokenMatchers.token_matchers(:numeric,  :muldiv,         :numeric),
+        math_neg_mul: TokenMatchers.token_matchers(:numeric,  :muldiv,         :subtract, :numeric),
+        math_pow:     TokenMatchers.token_matchers(:numeric,  :pow,            :numeric),
+        math_neg_pow: TokenMatchers.token_matchers(:numeric,  :pow,            :subtract, :numeric),
+        math_mod:     TokenMatchers.token_matchers(:numeric,  :mod,            :numeric),
+        negation:     TokenMatchers.token_matchers(:subtract, :numeric),
+        start_neg:    TokenMatchers.token_matchers(:anchored_minus, :numeric),
+        percentage:   TokenMatchers.token_matchers(:numeric,  :mod),
+        range_asc:    TokenMatchers.token_matchers(:numeric,  :comp_lt,        :numeric,  :comp_lt, :numeric),
+        range_desc:   TokenMatchers.token_matchers(:numeric,  :comp_gt,        :numeric,  :comp_gt, :numeric),
+        num_comp:     TokenMatchers.token_matchers(:numeric,  :comparator,     :numeric),
+        str_comp:     TokenMatchers.token_matchers(:string,   :comparator,     :string),
+        combine:      TokenMatchers.token_matchers(:logical,  :combinator,     :logical),
 
-        if:           function_token_matchers(:if,        :non_group,      :comma, :non_group, :comma, :non_group),
-        round:        function_token_matchers(:round,     :arguments),
-        roundup:      function_token_matchers(:roundup,   :arguments),
-        rounddown:    function_token_matchers(:rounddown, :arguments),
-        not:          function_token_matchers(:not,       :arguments)
-      }
+        if:           TokenMatchers.function_token_matchers(:if,        :non_group,      :comma, :non_group, :comma, :non_group),
+        round:        TokenMatchers.function_token_matchers(:round,     :arguments),
+        roundup:      TokenMatchers.function_token_matchers(:roundup,   :arguments),
+        rounddown:    TokenMatchers.function_token_matchers(:rounddown, :arguments),
+        not:          TokenMatchers.function_token_matchers(:not,       :arguments)
+      }.merge(Math.patterns)
 
       @patterns[name]
-    end
-
-    def token_matchers(*symbols)
-      symbols.map { |s| matcher(s) }
-    end
-
-    def function_token_matchers(function_name, *symbols)
-      token_matchers(:fopen, *symbols, :close).unshift(
-        TokenMatcher.send(function_name)
-      )
     end
 
     def matcher(symbol)

--- a/lib/dentaku/token_matchers.rb
+++ b/lib/dentaku/token_matchers.rb
@@ -1,0 +1,29 @@
+module Dentaku
+  module TokenMatchers
+    def self.token_matchers(*symbols)
+      symbols.map { |s| matcher(s) }
+    end
+
+    def self.function_token_matchers(function_name, *symbols)
+      token_matchers(:fopen, *symbols, :close).unshift(
+        TokenMatcher.send(function_name)
+      )
+    end
+
+    def self.matcher(symbol)
+      @matchers ||= [
+        :numeric, :string, :addsub, :subtract, :muldiv, :pow, :mod,
+        :comparator, :comp_gt, :comp_lt, :fopen, :open, :close, :comma,
+        :non_close_plus, :non_group, :non_group_star, :arguments,
+        :logical, :combinator, :if, :round, :roundup, :rounddown, :not,
+        :anchored_minus, :math_neg_pow, :math_neg_mul
+      ].each_with_object({}) do |name, matchers|
+        matchers[name] = TokenMatcher.send(name)
+      end
+
+      @matchers.fetch(symbol) do
+        raise "Unknown token symbol #{ symbol }"
+      end
+    end
+  end
+end

--- a/spec/calculator_spec.rb
+++ b/spec/calculator_spec.rb
@@ -198,4 +198,16 @@ describe Dentaku::Calculator do
       expect(calculator.evaluate('NOT(some_boolean) AND -1 > 3', some_boolean: true)).to be_falsey
     end
   end
+
+  describe 'math functions' do
+    Math.methods(false).each do |method|
+      it method do
+        if Math.method(method).arity == 2
+          expect(calculator.evaluate("#{method}(1,2)")).to eq Math.send(method, 1, 2)
+        else
+          expect(calculator.evaluate("#{method}(1)")).to eq Math.send(method, 1)
+        end
+      end
+    end
+  end
 end

--- a/spec/evaluator_spec.rb
+++ b/spec/evaluator_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'dentaku/token_matcher'
 require 'dentaku/evaluator'
 
 describe Dentaku::Evaluator do

--- a/spec/external_function_spec.rb
+++ b/spec/external_function_spec.rb
@@ -13,7 +13,7 @@ describe Dentaku::Calculator do
 
         fns = [
           {
-            name:      :exp,
+            name:      :cexp,
             type:      :numeric,
             signature: [ :numeric, :numeric ],
             body:      ->(mantissa, exponent) { mantissa ** exponent }
@@ -41,10 +41,10 @@ describe Dentaku::Calculator do
         expect(now).not_to be_empty
       end
 
-      it 'includes EXP' do
-        expect(with_external_funcs.evaluate('EXP(2,3)')).to eq(8)
-        expect(with_external_funcs.evaluate('EXP(3,2)')).to eq(9)
-        expect(with_external_funcs.evaluate('EXP(mantissa,exponent)', mantissa: 2, exponent: 4)).to eq(16)
+      it 'includes CEXP' do
+        expect(with_external_funcs.evaluate('CEXP(2,3)')).to eq(8)
+        expect(with_external_funcs.evaluate('CEXP(3,2)')).to eq(9)
+        expect(with_external_funcs.evaluate('CEXP(mantissa,exponent)', mantissa: 2, exponent: 4)).to eq(16)
       end
 
       it 'includes MAX' do

--- a/spec/rule_set_spec.rb
+++ b/spec/rule_set_spec.rb
@@ -26,7 +26,7 @@ describe Dentaku::RuleSet do
                              :apply,
                              :apply,
                              :apply,
-                            ]
+                            ].concat(Dentaku::Math.exported_methods)
   end
 
   it 'adds custom function patterns' do


### PR DESCRIPTION
This is not ready to merge, but would appreciate feedback so I can finish it properly.

I want to add all the [Math](http://ruby-doc.org/core-2.2.0/Math.html) functions. I can do this manually, or maybe something like what's proposed in this PR, via `Math.methods - Object.methods`. Or maybe `rule_set.rb` should define those explicitly and then we can hard-code the list and create a generic way for evaluating these.

Most functions take 1 argument, some 2. I am probably evaluating things wrong, I am supposed to use `evaluate_token_stream` somewhere?

Generally I want to add most of https://github.com/dblock/excalc/blob/master/common/MCalc.pas#L21.