### PR TITLE
Add dependencies method to node

### DIFF
--- a/lib/dentaku.rb
+++ b/lib/dentaku.rb
@@ -3,6 +3,9 @@ require "dentaku/calculator"
 require "dentaku/version"
 
 module Dentaku
+  @enable_ast_caching = false
+  @enable_dependency_order_caching = false
+
   def self.evaluate(expression, data={})
     calculator.evaluate(expression, data)
   end

--- a/lib/dentaku/ast/node.rb
+++ b/lib/dentaku/ast/node.rb
@@ -8,6 +8,10 @@ module Dentaku
       def self.arity
         nil
       end
+
+      def dependencies(context={})
+        []
+      end
     end
   end
 end

--- a/spec/ast/node_spec.rb
+++ b/spec/ast/node_spec.rb
@@ -22,6 +22,9 @@ describe Dentaku::AST::Node do
 
     node = make_node('if(x > 5, y, z)')
     expect(node.dependencies('x' => 7)).to eq ['y', 'z']
+
+    node = make_node('')
+    expect(node.dependencies).to eq []
   end
 
   it 'returns unique list of dependencies' do


### PR DESCRIPTION
First commit is just something I threw in because it was adding noise while debugging. I am happy to drop it.

Second commit is to enable me to go through a list of formulas and ask for all the dependencies, where some of the formulas are just nil. They're empty because they're in a path that isn't going to be used.

```
switch: 'first_path'
first_path: 1
second_path: null
outcome: "IF(switch = 'first_path', first_path, second_path)"
```

`second_path` is null because it was assigned programmatically.

Actually, I realize this need doesn't totally make sense  because it's based on how our internal library is structured, but I think in general it's a good idea for nodes to have a compatible interface if possible.