### PR TITLE
Pass var_name to error handler in bulk solver

### DIFF
--- a/lib/dentaku/bulk_expression_solver.rb
+++ b/lib/dentaku/bulk_expression_solver.rb
@@ -37,7 +37,7 @@ module Dentaku
     end
 
     def raise_exception_handler
-      ->(ex) { raise ex }
+      ->(ex, var_name) { raise ex }
     end
 
     def load_results(&block)
@@ -46,7 +46,7 @@ module Dentaku
           r[var_name] = calculator.memory[var_name] ||
                         evaluate!(expressions[var_name], expressions.merge(r))
         rescue Dentaku::UnboundVariableError, ZeroDivisionError => ex
-          r[var_name] = block.call(ex)
+          r[var_name] = block.call(ex, var_name)
         end
       end
     end

--- a/spec/bulk_expression_solver_spec.rb
+++ b/spec/bulk_expression_solver_spec.rb
@@ -55,5 +55,12 @@ RSpec.describe Dentaku::BulkExpressionSolver do
       expect(described_class.new(expressions, calculator).solve { :foo })
         .to eq(more_apples: :foo)
     end
+
+    it "passes the name of the failed expression in the custom error handler" do
+      expressions = {more_apples: "apples + 1"}
+      solver = described_class.new(expressions, calculator)
+      expect(solver.solve { |ex, name| "#{name}_foo" })
+        .to eq(more_apples: "more_apples_foo")
+    end
   end
 end


### PR DESCRIPTION
This could be useful for building the error, but it is also useful for
using the value passed into the block to add to data structures outside
the block.