### PR TITLE
Unbound variables blocking additional formulae

### DIFF
--- a/lib/dentaku/calculator.rb
+++ b/lib/dentaku/calculator.rb
@@ -32,11 +32,14 @@ module Dentaku
     end
 
     def evaluate!(expression, data={})
+      restore = Hash[memory]
       store(data) do
         node = expression
         node = ast(node) unless node.is_a?(AST::Node)
         node.value(memory)
       end
+    ensure
+      @memory = restore
     end
 
     def solve!(expression_hash)

--- a/spec/calculator_spec.rb
+++ b/spec/calculator_spec.rb
@@ -126,7 +126,7 @@ describe Dentaku::Calculator do
     end
 
     it "solves remainder of expressions with unbound variable" do
-      calculator.store(peaches: 1)
+      calculator.store(peaches: 1, oranges: 1)
       expressions = {more_apples: "apples + 1", more_peaches: "peaches + 1"}
       expect(calculator.solve(expressions)).to eq(
         more_apples: :undefined,

--- a/spec/calculator_spec.rb
+++ b/spec/calculator_spec.rb
@@ -125,6 +125,15 @@ describe Dentaku::Calculator do
       expect(calculator.solve(expressions)).to eq(more_apples: :undefined)
     end
 
+    it "solves remainder of expressions with unbound variable" do
+      calculator.store(peaches: 1)
+      expressions = {more_apples: "apples + 1", more_peaches: "peaches + 1"}
+      expect(calculator.solve(expressions)).to eq(
+        more_apples: :undefined,
+        more_peaches: 2
+      )
+    end
+
     it "allows passing in a custom value to an error handler" do
       expressions = {more_apples: "apples + 1"}
       expect(calculator.solve(expressions) { :foo })


### PR DESCRIPTION
This is not a great fix, but I am posting this to get some feedback. The issue occurs when using `calculator.solve` and there is an unbound variable error raised. The memory is changed and never gets reset in `store`. I _think_ that it might be best to remove the block behavior from store since it is changing the `@memory` instance variable but thought I would get some input. Let me know if you have thoughts about how to improve this.