### PR TITLE
Allow ROUNDUP & ROUNDDOWN functions to accept precision argument

### DIFF
--- a/lib/dentaku/ast/functions/rounddown.rb
+++ b/lib/dentaku/ast/functions/rounddown.rb
@@ -1,10 +1,7 @@
 require_relative '../function'
 
 Dentaku::AST::Function.register(:rounddown, :numeric, ->(numeric, precision=0) {
-  if precision == 0 # Ensure int is returned
-    numeric.floor
-  else
-    tens = 10.0**precision
-    (numeric * tens).floor / tens
-  end
+  tens = 10.0**precision
+  result = (numeric * tens).floor / tens
+  precision <= 0 ? result.to_i : result
 })

--- a/lib/dentaku/ast/functions/rounddown.rb
+++ b/lib/dentaku/ast/functions/rounddown.rb
@@ -1,5 +1,10 @@
 require_relative '../function'
 
-Dentaku::AST::Function.register(:rounddown, :numeric, ->(numeric) {
-  numeric.floor
+Dentaku::AST::Function.register(:rounddown, :numeric, ->(numeric, precision=0) {
+  if precision == 0 # Ensure int is returned
+    numeric.floor
+  else
+    tens = 10.0**precision
+    (numeric * tens).floor / tens
+  end
 })

--- a/lib/dentaku/ast/functions/roundup.rb
+++ b/lib/dentaku/ast/functions/roundup.rb
@@ -1,10 +1,7 @@
 require_relative '../function'
 
 Dentaku::AST::Function.register(:roundup, :numeric, ->(numeric, precision=0) {
-  if precision == 0 # Ensure int is returned
-    numeric.ceil
-  else
-    tens = 10.0**precision
-    (numeric * tens).ceil / tens
-  end
+  tens = 10.0**precision
+  result = (numeric * tens).ceil / tens
+  precision <= 0 ? result.to_i : result
 })

--- a/lib/dentaku/ast/functions/roundup.rb
+++ b/lib/dentaku/ast/functions/roundup.rb
@@ -1,5 +1,10 @@
 require_relative '../function'
 
-Dentaku::AST::Function.register(:roundup, :numeric, ->(numeric) {
-  numeric.ceil
+Dentaku::AST::Function.register(:roundup, :numeric, ->(numeric, precision=0) {
+  if precision == 0 # Ensure int is returned
+    numeric.ceil
+  else
+    tens = 10.0**precision
+    (numeric * tens).ceil / tens
+  end
 })

--- a/spec/calculator_spec.rb
+++ b/spec/calculator_spec.rb
@@ -238,6 +238,26 @@ describe Dentaku::Calculator do
       result = calculator.evaluate('number_of_sheets / if(multi_color, sheets_per_minute_color, sheets_per_minute_black)')
       expect(result).to eq(5)
     end
+
+    describe 'roundup' do
+      it 'should work with one argument' do
+        expect(calculator.evaluate('roundup(1.234)')).to eq(2)
+      end
+
+      it 'should accept second precision argument like in Office formula' do
+        expect(calculator.evaluate('roundup(1.234, 2)')).to eq(1.24)
+      end
+    end
+
+    describe 'rounddown' do
+      it 'should work with one argument' do
+        expect(calculator.evaluate('rounddown(1.234)')).to eq(1)
+      end
+
+      it 'should accept second precision argument like in Office formula' do
+        expect(calculator.evaluate('rounddown(1.234, 2)')).to eq(1.23)
+      end
+    end
   end
 
   describe 'case statements' do


### PR DESCRIPTION
In MS Excel, `ROUNDUP` and `ROUNDDOWN` accept optional second argument to specify amount of decimal places to round to. 

I use Dentaku to allow end users to configure calculations in system, and this difference has been tripping up the more excel-experienced among them.