### PR TITLE
Add the concept of NULL

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ BUILT-IN OPERATORS AND FUNCTIONS
 
 Math: `+ - * / %`
 
-Logic: `< > <= >= <> != = AND OR`
+Logic: `< > <= >= <> != = AND OR NULL`
 
 Functions: `IF NOT MIN MAX ROUND ROUNDDOWN ROUNDUP`
 

--- a/lib/dentaku/ast/identifier.rb
+++ b/lib/dentaku/ast/identifier.rb
@@ -10,12 +10,13 @@ module Dentaku
       end
 
       def value(context={})
-        v = context[identifier]
+        v = context.fetch(identifier) do
+          raise UnboundVariableError.new([identifier])
+        end
+
         case v
         when Node
           v.value(context)
-        when NilClass
-          raise UnboundVariableError.new([identifier])
         else
           v
         end

--- a/lib/dentaku/bulk_expression_solver.rb
+++ b/lib/dentaku/bulk_expression_solver.rb
@@ -43,8 +43,18 @@ module Dentaku
     def load_results(&block)
       variables_in_resolve_order.each_with_object({}) do |var_name, r|
         begin
-          r[var_name] = calculator.memory[var_name] ||
-                        evaluate!(expressions[var_name], expressions.merge(r))
+          value_from_memory = calculator.memory[var_name]
+
+          if value_from_memory.nil? &&
+              expressions[var_name].nil? &&
+              !calculator.memory.has_key?(var_name)
+            next
+          end
+
+          value = value_from_memory ||
+            evaluate!(expressions[var_name], expressions.merge(r))
+
+          r[var_name] = value
         rescue Dentaku::UnboundVariableError, ZeroDivisionError => ex
           r[var_name] = block.call(ex)
         end

--- a/lib/dentaku/parser.rb
+++ b/lib/dentaku/parser.rb
@@ -54,6 +54,9 @@ module Dentaku
             operations.push op_class
           end
 
+        when :null
+          output.push AST::Nil.new
+
         when :function
           arities.push 0
           operations.push function(token)

--- a/lib/dentaku/token_scanner.rb
+++ b/lib/dentaku/token_scanner.rb
@@ -26,6 +26,7 @@ module Dentaku
     class << self
       def available_scanners
         [
+          :null,
           :whitespace,
           :numeric,
           :double_quoted_string,
@@ -66,6 +67,10 @@ module Dentaku
 
       def whitespace
         new(:whitespace, '\s+')
+      end
+
+      def null
+        new(:null, 'null\b')
       end
 
       def numeric

--- a/spec/calculator_spec.rb
+++ b/spec/calculator_spec.rb
@@ -264,6 +264,22 @@ describe Dentaku::Calculator do
     it 'can be used in IF statements' do
       expect(calculator.evaluate('IF(null, 1, 2)')).to eq(2)
     end
+
+    it 'can be used in IF statements when passed in' do
+      expect(calculator.evaluate('IF(foo, 1, 2)', foo: nil)).to eq(2)
+    end
+
+    it 'nil values are carried across middle terms' do
+      results = calculator.solve!(
+        choice: 'IF(bar, 1, 2)',
+        bar: 'foo',
+        foo: nil)
+      expect(results).to eq(
+        choice: 2,
+        bar: nil,
+        foo: nil
+      )
+    end
   end
 
   describe 'case statements' do

--- a/spec/calculator_spec.rb
+++ b/spec/calculator_spec.rb
@@ -260,6 +260,12 @@ describe Dentaku::Calculator do
     end
   end
 
+  describe 'explicit NULL' do
+    it 'can be used in IF statements' do
+      expect(calculator.evaluate('IF(null, 1, 2)')).to eq(2)
+    end
+  end
+
   describe 'case statements' do
     it 'handles complex then statements' do
       formula = <<-FORMULA

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -133,4 +133,10 @@ describe Dentaku::Parser do
       described_class.new([five, times, minus]).parse
     }.to raise_error(Dentaku::ParseError)
   end
+
+  it "evaluates explicit 'NULL' as a Nil" do
+    null  = Dentaku::Token.new(:null, nil)
+    node = described_class.new([null]).parse
+    expect(node.value).to eq(nil)
+  end
 end

--- a/spec/token_scanner_spec.rb
+++ b/spec/token_scanner_spec.rb
@@ -28,7 +28,7 @@ describe Dentaku::TokenScanner do
   end
 
   it 'returns a list of all configured scanners' do
-    expect(described_class.scanners.length).to eq 13
+    expect(described_class.scanners.length).to eq 14
   end
 
   it 'allows customizing available scanners' do


### PR DESCRIPTION
```
Allow NULL to be referenced in formulas, and for passed-in variables to
have the value of 'null', which is evaluated as nil.
```

I would understand if you're not interested in this change. We need it because we want to have a function like this:

```ruby
@calculator.add_function(:sum_values, :numeric, ->(*args) {
  args.reject! { |arg| arg.is_a?(String) }

  if args.none?
    ''
  else
    args.inject(BigDecimal('0.0')) do |sum, item|
      sum + (item || BigDecimal('0.0'))
    end
  end
})
```

... where the idea is that you only add up the values that are numeric. The reason that some charges are strings is because we are currently passing in the value of those variables as the string 'null'. This is because if the values of these variables was actually nil then the calculator would raise an unbound variable error *before* entering this function. And while this works, it's not great because we still have to pass back another string afterwards, requiring lots of `blah != ''` checks throughout our calculations.