### PR TITLE
Store variable that had the issue on exception

### DIFF
--- a/lib/dentaku/ast/arithmetic.rb
+++ b/lib/dentaku/ast/arithmetic.rb
@@ -68,7 +68,7 @@ module Dentaku
     class Division < Arithmetic
       def value(context={})
         r = cast(right.value(context), false)
-        raise ZeroDivisionError if r.zero?
+        raise Dentaku::ZeroDivisionError if r.zero?
 
         cast(cast(left.value(context)) / r)
       end

--- a/lib/dentaku/bulk_expression_solver.rb
+++ b/lib/dentaku/bulk_expression_solver.rb
@@ -46,6 +46,7 @@ module Dentaku
           r[var_name] = calculator.memory[var_name] ||
                         evaluate!(expressions[var_name], expressions.merge(r))
         rescue Dentaku::UnboundVariableError, ZeroDivisionError => ex
+          ex.recipient_variable = var_name
           r[var_name] = block.call(ex)
         end
       end

--- a/lib/dentaku/exceptions.rb
+++ b/lib/dentaku/exceptions.rb
@@ -1,5 +1,7 @@
 module Dentaku
   class UnboundVariableError < StandardError
+    attr_accessor :recipient_variable
+
     attr_reader :unbound_variables
 
     def initialize(unbound_variables)
@@ -9,5 +11,9 @@ module Dentaku
   end
 
   class ParseError < StandardError
+  end
+
+  class ZeroDivisionError < ::ZeroDivisionError
+    attr_accessor :recipient_variable
   end
 end

--- a/spec/bulk_expression_solver_spec.rb
+++ b/spec/bulk_expression_solver_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Dentaku::BulkExpressionSolver do
       expressions = {more_apples: "1/0"}
       expect {
         described_class.new(expressions, calculator).solve!
-      }.to raise_error(ZeroDivisionError)
+      }.to raise_error(Dentaku::ZeroDivisionError)
     end
 
     it "does not require keys to be parseable" do
@@ -54,6 +54,24 @@ RSpec.describe Dentaku::BulkExpressionSolver do
       expressions = {more_apples: "1/0"}
       expect(described_class.new(expressions, calculator).solve { :foo })
         .to eq(more_apples: :foo)
+    end
+
+    it 'stores the recipient variable on the exception when there is a div/0 error' do
+      expressions = {more_apples: "1/0"}
+      exception = nil
+      described_class.new(expressions, calculator).solve do |ex|
+        exception = ex
+      end
+      expect(exception.recipient_variable).to eq('more_apples')
+    end
+
+    it 'stores the recipient variable on the exception when there is an unbound variable' do
+      expressions = {more_apples: "apples + 1"}
+      exception = nil
+      described_class.new(expressions, calculator).solve do |ex|
+        exception = ex
+      end
+      expect(exception.recipient_variable).to eq('more_apples')
     end
   end
 end


### PR DESCRIPTION
(This is the solution that was arrived at after discussion here https://github.com/rubysolo/dentaku/pull/63)

The BulkExpressionSolver provides an interface for customizing return
values when it throws an UnboundVariableError or a ZeroDivisionError
while trying to evaluate an expression. Right now there isn't a way to
know the name of the variable that we were attempting to assign the
evaluated expression to. This commit attaches a `recipient_variable`
to the exception. This requires creating a customized subclass of
ZeroDivisionError that belongs to Dentaku.