### PR TITLE
Fail with dentaku-specific error in case arithmetic operand is invalid

### DIFF
--- a/lib/dentaku/ast/arithmetic.rb
+++ b/lib/dentaku/ast/arithmetic.rb
@@ -37,8 +37,8 @@ module Dentaku
 
       def validate_numeric(value)
         Float(value)
-      rescue ArgumentError
-        fail ArgumentError, "#{ self.class } requires numeric operands"
+      rescue ::ArgumentError, ::TypeError
+        fail Dentaku::ArgumentError, "#{ self.class } requires numeric operands"
       end
     end
 

--- a/lib/dentaku/exceptions.rb
+++ b/lib/dentaku/exceptions.rb
@@ -13,6 +13,9 @@ module Dentaku
   class ParseError < StandardError
   end
 
+  class ArgumentError < ::ArgumentError
+  end
+
   class ZeroDivisionError < ::ZeroDivisionError
     attr_accessor :recipient_variable
   end

--- a/spec/calculator_spec.rb
+++ b/spec/calculator_spec.rb
@@ -281,6 +281,12 @@ describe Dentaku::Calculator do
         foo: nil
       )
     end
+
+    it 'should still raise errors in arhitmetic operations' do
+      expect {
+        calculator.solve!(more_apples: "apples + 1", apples: nil)
+      }.to raise_error(Dentaku::ArgumentError)
+    end
   end
 
   describe 'case statements' do


### PR DESCRIPTION
Updating from 2.0.6 to 2.0.7 broke a whole lot of tests in my app, all due to how null functions in arhitmetic operations. What previously threw `Dentaku::UnboundVariableError` now non-dentaku-namespaced errors.

This PR:

1) Catches `TypeError` in arithmetic operand validation (consider catch-all case there?);

2) Introduces `Dentaku`-namespaced `ArgumentError` so that users of gem can continue to explicitly catch formula-related errors.