### PR TITLE
Make register check constant only on Dentaku::AST

### DIFF
--- a/lib/dentaku/ast/function.rb
+++ b/lib/dentaku/ast/function.rb
@@ -46,7 +46,7 @@ module Dentaku
         end
 
         function_class = name.to_s.capitalize
-        Dentaku::AST.send(:remove_const, function_class) if Dentaku::AST.const_defined?(function_class)
+        Dentaku::AST.send(:remove_const, function_class) if Dentaku::AST.const_defined?(function_class, false)
         Dentaku::AST.const_set(function_class, function)
 
         function.implementation = implementation

--- a/spec/ast/function_spec.rb
+++ b/spec/ast/function_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 require 'dentaku/ast/function'
 
+class Clazz; end
+
 describe Dentaku::AST::Function do
   it 'maintains a function registry' do
     expect(described_class).to respond_to(:get)
@@ -17,5 +19,9 @@ describe Dentaku::AST::Function do
     expect { described_class.get("flarble") }.not_to raise_error
     function = described_class.get("flarble").new
     expect(function.value).to eq "flarble"
+  end
+
+  it 'does not throw an error when registering a function with a name that matches a currently defined constant' do
+    expect { described_class.register("clazz", :string, -> { "clazzified" }) }.not_to raise_error
   end
 end


### PR DESCRIPTION
Currently, if there is a class called "Something" and a function
is registered with the name "something", a NameError will be raised.

That happens because Dentaku::AST::Function.register will try to verify
if "Something" is currently defined on Dentaku::AST with
"const_defined?".

If there is a class defined in the Top-level object with that name,
"const_defined?" will return true, and then the "register" method will
try to undefine it before redefining, throwing the NameError (as
Dentaku::AST::Something is not defined).

This fixes that error by adding the second parameter to the
"const_defined?" call as described here
https://ruby-doc.org/core-1.9.2/Module.html#method-i-const_defined-3F.

By calling "const_defined?" with false as the second parameter, it will
only check the constants defined in Dentaku::AST and not any of its
ancestors.