### PR TITLE
Support Hash data on `store` method

### DIFF
--- a/lib/dentaku/token_scanner.rb
+++ b/lib/dentaku/token_scanner.rb
@@ -133,7 +133,7 @@ module Dentaku
       end
 
       def identifier
-        new(:identifier, '\w+\b', lambda { |raw| raw.strip.downcase })
+        new(:identifier, '[\w\.]+\b', lambda { |raw| raw.strip.downcase })
       end
     end
 


### PR DESCRIPTION
This allows you to use for example:

```ruby
calculator = Dentaku::Calculator.new
calculator.store({a: { b: {c: {d: 5}}}})
calculator.evaluate('a.b.c.d == 5') # => true
```

Running RSpec, gave no errors. Maybe someone should write unit tests for this, I don't have time right now.