### PR TITLE
Fix Negation when variable is a String

### DIFF
--- a/lib/dentaku/ast/negation.rb
+++ b/lib/dentaku/ast/negation.rb
@@ -1,13 +1,13 @@
 module Dentaku
   module AST
-    class Negation < Operation
+    class Negation < Arithmetic
       def initialize(node)
         @node = node
         fail ParseError, "Negation requires numeric operand" unless valid_node?(node)
       end
 
       def value(context={})
-        @node.value(context) * -1
+        cast(@node.value(context)) * -1
       end
 
       def type

--- a/spec/calculator_spec.rb
+++ b/spec/calculator_spec.rb
@@ -169,6 +169,13 @@ describe Dentaku::Calculator do
     expect(calculator.evaluate('(1+1+1)/3*100')).to eq(100)
   end
 
+  it 'evaluates negation' do
+    expect(calculator.evaluate('-negative', negative: -1)).to eq(1)
+    expect(calculator.evaluate('-negative', negative: '-1')).to eq(1)
+    expect(calculator.evaluate('-negative - 1', negative: '-1')).to eq(0)
+    expect(calculator.evaluate('-negative - 1', negative: '1')).to eq(-2)
+  end
+
   it 'fails to evaluate unbound statements' do
     unbound = 'foo * 1.5'
     expect { calculator.evaluate!(unbound) }.to raise_error(Dentaku::UnboundVariableError)


### PR DESCRIPTION
First of all, thanks for you time.

This PR aims to solve Issue #93.

![screen shot 2017-01-16 at 12 41 31](https://cloud.githubusercontent.com/assets/410080/21981739/2c41ff08-dbe9-11e6-8602-4c754bbbc5e3.png)

Since we need a cast I decided to inherit from [Arithmetic](https://github.com/rubysolo/dentaku/blob/master/lib/dentaku/ast/arithmetic.rb) that is the current approach that we use on `Addition`, `Subtraction` and so on.

I tried to touch less code as possible.
Please let me know if I need to change something.

This gem is awesome! It has a great API and great features! Well Done @rubysolo!
