### PR TITLE
Duck type arithmetic

### DIFF
--- a/lib/dentaku/ast/arithmetic.rb
+++ b/lib/dentaku/ast/arithmetic.rb
@@ -16,6 +16,10 @@ module Dentaku
         :numeric
       end
 
+      def operator
+        raise "Not implemented"
+      end
+
       def value(context={})
         l = cast(left.value(context))
         r = cast(right.value(context))
@@ -25,7 +29,7 @@ module Dentaku
       private
 
       def cast(value, prefer_integer=true)
-        validate_numeric(value)
+        validate_operation(value)
         v = BigDecimal.new(value, Float::DIG+1)
         v = v.to_i if prefer_integer && v.frac.zero?
         v
@@ -38,10 +42,10 @@ module Dentaku
         node && (node.dependencies.any? || node.type == :numeric)
       end
 
-      def validate_numeric(value)
-        Float(value)
-      rescue ::ArgumentError, ::TypeError
-        fail Dentaku::ArgumentError, "#{ self.class } requires numeric operands"
+      def validate_operation(value)
+        unless value.respond_to?(operator)
+          fail Dentaku::ArgumentError, "#{ self.class } requires operands that respond to #{operator}"
+        end
       end
     end
 
@@ -76,6 +80,10 @@ module Dentaku
     end
 
     class Division < Arithmetic
+      def operator
+        :/
+      end
+
       def value(context={})
         r = cast(right.value(context), false)
         raise Dentaku::ZeroDivisionError if r.zero?

--- a/lib/dentaku/ast/negation.rb
+++ b/lib/dentaku/ast/negation.rb
@@ -6,6 +6,10 @@ module Dentaku
         fail ParseError, "Negation requires numeric operand" unless valid_node?(node)
       end
 
+      def operator
+        :*
+      end
+
       def value(context={})
         cast(@node.value(context)) * -1
       end

--- a/spec/ast/addition_spec.rb
+++ b/spec/ast/addition_spec.rb
@@ -26,4 +26,31 @@ describe Dentaku::AST::Addition do
       described_class.new(group, five)
     }.not_to raise_error
   end
+
+  it 'allows operands that respond to addition' do
+    # Sample struct that has a custom definition for addition
+    
+    Operand = Struct.new(:value) do
+      def +(other)
+        case other
+        when Operand
+          value + other.value
+        when Numeric
+          value + other
+        end
+      end
+    end
+
+    operand_five = Dentaku::AST::Logical.new Dentaku::Token.new(:numeric, Operand.new(5))
+    operand_six = Dentaku::AST::Logical.new Dentaku::Token.new(:numeric, Operand.new(6))
+
+    expect {
+      described_class.new(operand_five, operand_six)
+    }.not_to raise_error
+
+    expect {
+      described_class.new(operand_five, six)
+    }.not_to raise_error
+
+  end
 end

--- a/spec/calculator_spec.rb
+++ b/spec/calculator_spec.rb
@@ -31,7 +31,7 @@ describe Dentaku::Calculator do
     expect(calculator.evaluate('(((695759/735000)^(1/(1981-1991)))-1)*1000').round(4)).to eq(5.5018)
     expect(calculator.evaluate('0.253/0.253')).to eq(1)
     expect(calculator.evaluate('0.253/d', d: 0.253)).to eq(1)
-    expect(calculator.evaluate('10 + x', x: 'abc')).to be_nil
+    expect(calculator.evaluate('10 + x', x: 'abc')).to eq(10) # x variable get's parsed as 0 when converted to BigDecimal
     expect(calculator.evaluate('t + 1*24*60*60', t: Time.local(2017, 1, 1))).to eq(Time.local(2017, 1, 2))
   end
 


### PR DESCRIPTION
Hi, one of the needs I came across in this gem was the ability to support arithmetic on more than just Numeric values. Out specific use case was to use support unit operations from the [Ruby Units](https://github.com/olbrich/ruby-units) library. 

The way I went about implementing it was stop force casting the arithmetic operands to Floats and instead just check if they respond to the operation you're about to run. But I still wanted to remain as backwards compatible as possible so I left the logic that would try to convert the operand to a float and if it failed it would use the value as is with the code already having confirmed that you will be able to run the arithmetic operation you're trying to run.

Writing it this way caused only one breaking change in a test. The expression `10 + x` where x is the string `abc` used to return nil and because of this change, string get's turned into a BigDecimal and parsed as 0 so the above expression returns 10. I'm open to suggestions on how you want to handle that case.
Also because of the same conversion I described above you could never write an equation that was `'abc' + 'abc'`. The user might expect that to return `abcabc` but it will actually return 0.

This would fix #73 without having to add explicit support to the gem for every library that might want to take part in calculations.

I wrote a couple tests for the addition operator being used on an arbitrary struct that supports addition. If you like this change I can write tests to for the rest of the operators.

I'm open to any suggestions you have to improve this implementation. Obviously it changes some assumptions in the library that were previously true (For instance the `type` of an arithmetic operation was, and still does, return `:numeric` which isn't strictly true any more).

Let me know what you think!