### PR TITLE
Time literals can contain timezone information

### DIFF
--- a/lib/dentaku/token_scanner.rb
+++ b/lib/dentaku/token_scanner.rb
@@ -77,7 +77,7 @@ module Dentaku
 
       # NOTE: Convert to DateTime as Array(Time) returns the parts of the time for some reason
       def datetime
-        new(:datetime, '\d{2}\d{2}?-\d{1,2}-\d{1,2}( \d{1,2}:\d{1,2}:\d{1,2})?', lambda { |raw| Time.parse(raw).to_datetime })
+        new(:datetime, /\d{2}\d{2}?-\d{1,2}-\d{1,2}( \d{1,2}:\d{1,2}:\d{1,2})? ?(Z|((\+|\-)\d{2}\:?\d{2}))?/, lambda { |raw| Time.parse(raw).to_datetime })
       end
 
       def numeric

--- a/spec/tokenizer_spec.rb
+++ b/spec/tokenizer_spec.rb
@@ -172,16 +172,18 @@ describe Dentaku::Tokenizer do
   end
 
   it 'tokenizes Time literals' do
-    tokens = tokenizer.tokenize('2017-01-01 2017-01-2 2017-1-03 2017-01-04 12:23:42 2017-1-5 1:2:3 2017-1-06 1:02:30')
-    expect(tokens.length).to eq(6)
-    expect(tokens.map(&:category)).to eq([:datetime, :datetime, :datetime, :datetime, :datetime, :datetime])
+    tokens = tokenizer.tokenize('2017-01-01 2017-01-2 2017-1-03 2017-01-04 12:23:42 2017-1-5 1:2:3 2017-1-06 1:02:30 2017-01-07 12:34:56 Z 2017-01-08 1:2:3 +0800')
+    expect(tokens.length).to eq(8)
+    expect(tokens.map(&:category)).to eq([:datetime, :datetime, :datetime, :datetime, :datetime, :datetime, :datetime, :datetime])
     expect(tokens.map(&:value)).to eq([
       Time.local(2017, 1, 1).to_datetime,
       Time.local(2017, 1, 2).to_datetime,
       Time.local(2017, 1, 3).to_datetime,
       Time.local(2017, 1, 4, 12, 23, 42).to_datetime,
       Time.local(2017, 1, 5, 1, 2, 3).to_datetime,
-      Time.local(2017, 1, 6, 1, 2, 30).to_datetime
+      Time.local(2017, 1, 6, 1, 2, 30).to_datetime,
+      Time.utc(2017, 1, 7, 12, 34, 56).to_datetime,
+      Time.new(2017, 1, 8, 1, 2, 3, "+08:00").to_datetime
     ])
   end
 


### PR DESCRIPTION
Time zone information can now be included in time literal strings.

For example:
```ruby
# Convert to seconds since unix epoch
calculator.evaluate("1970-01-01 00:00:00 Z").to_time.to_i == 0
calculator.evaluate("1970-01-01 00:00:00 -0100").to_time.to_i == 3600
```