### PR TITLE
Do not need to store function class on Dentaku::AST

### DIFF
--- a/lib/dentaku/ast/function_registry.rb
+++ b/lib/dentaku/ast/function_registry.rb
@@ -36,10 +36,6 @@ module Dentaku
           end
         end
 
-        function_class = name.to_s.capitalize.gsub('!', '_')
-        Dentaku::AST.send(:remove_const, function_class) if Dentaku::AST.const_defined?(function_class, false)
-        Dentaku::AST.const_set(function_class, function)
-
         function.implementation = implementation
         function.type = type
 

--- a/spec/external_function_spec.rb
+++ b/spec/external_function_spec.rb
@@ -62,10 +62,11 @@ describe Dentaku::Calculator do
     it 'does not store functions across all calculators' do
       calculator1 = Dentaku::Calculator.new
       calculator1.add_function(:my_function, :numeric, ->(x) { 2*x + 1 })
-      expect(calculator1.evaluate("1 + my_function(2)")). to eq (1 + 2*2 + 1)
 
       calculator2 = Dentaku::Calculator.new
       calculator2.add_function(:my_function, :numeric, ->(x) { 4*x + 3 })
+
+      expect(calculator1.evaluate("1 + my_function(2)")). to eq (1 + 2*2 + 1)
       expect(calculator2.evaluate("1 + my_function(2)")). to eq (1 + 4*2 + 3)
 
       expect{Dentaku::Calculator.new.evaluate("1 + my_function(2)")}.to raise_error(Dentaku::ParseError)


### PR DESCRIPTION
Continuation of #107.

I noticed that adding the same function `"my_function"` to different calculators caused the same class `Dentaku::AST::My_function` to be defined.  This PR changes the spec to make sure that the functions they reference remain different and are not just being overwritten.  And it removes the code which adds the class constant to `Dentaku::AST`.  All specs still pass with this code removal.

For reference, after this change the default function registry looks like (most are anonymous classes):
```ruby
# Dentaku::AST::FunctionRegistry.default
{"if"=>Dentaku::AST::If,
 "max"=>#<Class:0x00557fabaf8310>,
 "min"=>#<Class:0x00557fab61ddb8>,
 "not"=>#<Class:0x00557fab61c350>,
 "round"=>#<Class:0x00557fabb06de8>,
 "roundup"=>#<Class:0x00557fabb05650>,
 "rounddown"=>#<Class:0x00557fab613e80>,
 "atan2"=>#<Class:0x00557fabb13d18>,
 "cos"=>#<Class:0x00557fabb13ac0>,
 "sin"=>#<Class:0x00557fabb13868>,
 "tan"=>#<Class:0x00557fabb13610>,
 "acos"=>#<Class:0x00557fabb133b8>,
 "asin"=>#<Class:0x00557fabb13160>,
 "atan"=>#<Class:0x00557fabb12f08>,
 "cosh"=>#<Class:0x00557fabb12cb0>,
 "sinh"=>#<Class:0x00557fabb12a58>,
 "tanh"=>#<Class:0x00557fabb12800>,
 "acosh"=>#<Class:0x00557fabb125a8>,
 "asinh"=>#<Class:0x00557fabb12350>,
 "atanh"=>#<Class:0x00557fabb120f8>,
 "exp"=>#<Class:0x00557fabb11ea0>,
 "log"=>#<Class:0x00557fabb11c48>,
 "log2"=>#<Class:0x00557fabb119f0>,
 "log10"=>#<Class:0x00557fabb11798>,
 "sqrt"=>#<Class:0x00557fabb11540>,
 "cbrt"=>#<Class:0x00557fabb112e8>,
 "frexp"=>#<Class:0x00557fabb11090>,
 "ldexp"=>#<Class:0x00557fabb10e38>,
 "hypot"=>#<Class:0x00557fabb10be0>,
 "erf"=>#<Class:0x00557fabb10988>,
 "erfc"=>#<Class:0x00557fabb10730>,
 "gamma"=>#<Class:0x00557fabb104d8>,
 "lgamma"=>#<Class:0x00557fabb10280>,
 "left"=>Dentaku::AST::StringFunctions::Left,
 "right"=>Dentaku::AST::StringFunctions::Right,
 "mid"=>Dentaku::AST::StringFunctions::Mid,
 "len"=>Dentaku::AST::StringFunctions::Len,
 "find"=>Dentaku::AST::StringFunctions::Find,
 "substitute"=>Dentaku::AST::StringFunctions::Substitute,
 "concat"=>Dentaku::AST::StringFunctions::Concat,
 "contains"=>Dentaku::AST::StringFunctions::Contains}
```