### PR TITLE
[WIP] Record correct arity for custom functions

### DIFF
--- a/lib/dentaku/ast/custom_function.rb
+++ b/lib/dentaku/ast/custom_function.rb
@@ -1,0 +1,52 @@
+module Dentaku
+  module AST
+    class CustomFunction < Function
+      def self.name=(name)
+        @name = name
+      end
+
+      def self.name
+        @name
+      end
+
+      def name
+        self.class.name
+      end
+
+      # To keep everything functional, variable argument functions should
+      # have "nil" arity
+      def self.arity
+        @arity ||= implementation.arity < 0 ? nil : implementation.arity
+      end
+
+      def arity
+        self.class.arity
+      end
+
+      def self.implementation=(impl)
+        @implementation = impl
+      end
+
+      def self.implementation
+        @implementation
+      end
+
+      def self.type=(type)
+        @type = type
+      end
+
+      def self.type
+        @type
+      end
+
+      def value(context={})
+        args = @args.map { |a| a.value(context) }
+        self.class.implementation.call(*args)
+      end
+
+      def type
+        self.class.type
+      end
+    end
+  end
+end

--- a/lib/dentaku/ast/function.rb
+++ b/lib/dentaku/ast/function.rb
@@ -30,3 +30,5 @@ module Dentaku
     end
   end
 end
+
+require_relative 'custom_function'

--- a/lib/dentaku/ast/function_registry.rb
+++ b/lib/dentaku/ast/function_registry.rb
@@ -9,33 +9,9 @@ module Dentaku
       end
 
       def register(name, type, implementation)
-        function = Class.new(Function) do
-          def self.implementation=(impl)
-            @implementation = impl
-          end
+        function = Class.new(Dentaku::AST::CustomFunction)
 
-          def self.implementation
-            @implementation
-          end
-
-          def self.type=(type)
-            @type = type
-          end
-
-          def self.type
-            @type
-          end
-
-          def value(context={})
-            args = @args.map { |a| a.value(context) }
-            self.class.implementation.call(*args)
-          end
-
-          def type
-            self.class.type
-          end
-        end
-
+        function.name = name.to_sym
         function.implementation = implementation
         function.type = type
 

--- a/lib/dentaku/calculator.rb
+++ b/lib/dentaku/calculator.rb
@@ -7,7 +7,7 @@ require 'dentaku/parser'
 
 module Dentaku
   class Calculator
-    attr_reader :result, :memory, :tokenizer
+    attr_reader :result, :memory, :tokenizer, :function_registry
 
     def initialize(ast_cache={})
       clear

--- a/spec/ast/function_spec.rb
+++ b/spec/ast/function_spec.rb
@@ -4,6 +4,8 @@ require 'dentaku/ast/function'
 class Clazz; end
 
 describe Dentaku::AST::Function do
+  let(:calculator) { Dentaku::Calculator.new }
+
   it 'maintains a function registry' do
     expect(described_class).to respond_to(:get)
   end
@@ -15,13 +17,40 @@ describe Dentaku::AST::Function do
   end
 
   it 'registers a custom function' do
-    described_class.register("flarble", :string, -> { "flarble" })
-    expect { described_class.get("flarble") }.not_to raise_error
-    function = described_class.get("flarble").new
+    calculator.add_function("flarble", :string, -> { "flarble" })
+    function = calculator.function_registry.get("flarble").new
     expect(function.value).to eq "flarble"
   end
 
   it 'does not throw an error when registering a function with a name that matches a currently defined constant' do
-    expect { described_class.register("clazz", :string, -> { "clazzified" }) }.not_to raise_error
+    expect { calculator.add_function("clazz", :string, -> { "clazzified" }) }.not_to raise_error
+  end
+
+  describe "#name" do
+    it "for custom functions, gives a string representation of the function" do
+      calculator.add_function("alpha", :numeric, ->() { 10 })
+      function = calculator.function_registry.get("alpha").new
+      expect(function.name).to eq :alpha
+    end
+  end
+
+  describe "#arity" do
+    it "gives the correct arity for custom functions" do
+      calculator.add_function("alpha", :numeric, ->() { 10 })
+      function = calculator.function_registry.get("alpha").new
+      expect(function.arity).to eq 0
+
+      calculator.add_function("beta", :numeric, ->(x) { 2*x })
+      function = calculator.function_registry.get("beta").new
+      expect(function.arity).to eq 1
+
+      calculator.add_function("gamma", :numeric, ->(x,y) { x + y })
+      function = calculator.function_registry.get("gamma").new
+      expect(function.arity).to eq 2
+
+      calculator.add_function("delta", :numeric, ->(*args) { args.max })
+      function = calculator.function_registry.get("delta").new
+      expect(function.arity).to eq nil
+    end
   end
 end


### PR DESCRIPTION
Currently all custom functions have arity set to nil.  nil is treated as
variable arguments in the code, so it mostly works out, but for
consistency this should report the correct arity (but for now use nil
for variable argument cases).

Also adds a convenience method, `name` to check the name of anonymous functions when debugging.

Note that the changes to the spec are to prevent polluting the global registry with "flarble" and "clazz" functions.

This PR is motivated by the following error I encountered (see #112).  It does not fix it, but it does make more clear the problem.  The code is not correctly keeping track of arities in `Parser`, which is apparent when you define a function that takes no arguments:
```ruby
calculator = Dentaku::Calculator.new
calculator.add_function(:alpha, :numeric, -> { 2 })
calculator.evaluate("max(alpha(), 1)") # => 2
calculator.evaluate("max(1, alpha())") # => ParseError!
```