### PR TITLE
Remove cyclic require

### DIFF
--- a/lib/dentaku/bulk_expression_solver.rb
+++ b/lib/dentaku/bulk_expression_solver.rb
@@ -1,4 +1,3 @@
-require 'dentaku/calculator'
 require 'dentaku/dependency_resolver'
 require 'dentaku/exceptions'
 require 'dentaku/parser'

--- a/lib/dentaku/calculator.rb
+++ b/lib/dentaku/calculator.rb
@@ -1,4 +1,3 @@
-require 'dentaku/bulk_expression_solver'
 require 'dentaku/exceptions'
 require 'dentaku/token'
 require 'dentaku/dependency_resolver'

--- a/lib/dentaku/calculator.rb
+++ b/lib/dentaku/calculator.rb
@@ -1,3 +1,4 @@
+require 'dentaku/bulk_expression_solver'
 require 'dentaku/exceptions'
 require 'dentaku/token'
 require 'dentaku/dependency_resolver'


### PR DESCRIPTION
fix #106 
The first line in `lib/dentaku/bulk_expression_solver.rb` is unnecessary:
`require 'dentaku/calculator'`

And in file `lib/dentaku/calculator.rb` also required `dentaku/bulk_expression_solver`,
which leads to circular require.