### PR TITLE
Fix Division with String Arguments

### DIFF
--- a/lib/dentaku/ast/arithmetic.rb
+++ b/lib/dentaku/ast/arithmetic.rb
@@ -29,8 +29,12 @@ module Dentaku
       private
 
       def cast(val, prefer_integer=true)
-        validate_operation(val)
-        validate_format(val) if val.is_a?(::String)
+        if val.is_a?(::String)
+          validate_format(val)
+        else
+          validate_operation(val)
+        end
+
         numeric(val, prefer_integer)
       end
 

--- a/lib/dentaku/ast/arithmetic.rb
+++ b/lib/dentaku/ast/arithmetic.rb
@@ -29,12 +29,7 @@ module Dentaku
       private
 
       def cast(val, prefer_integer=true)
-        if val.is_a?(::String)
-          validate_format(val)
-        else
-          validate_operation(val)
-        end
-
+        validate_value(val)
         numeric(val, prefer_integer)
       end
 
@@ -58,6 +53,14 @@ module Dentaku
 
       def valid_right?
         valid_node?(right)
+      end
+
+      def validate_value(val)
+        if val.is_a?(::String)
+          validate_format(val)
+        else
+          validate_operation(val)
+        end
       end
 
       def validate_operation(val)

--- a/spec/calculator_spec.rb
+++ b/spec/calculator_spec.rb
@@ -32,6 +32,7 @@ describe Dentaku::Calculator do
     expect(calculator.evaluate('0.253/0.253')).to eq(1)
     expect(calculator.evaluate('0.253/d', d: 0.253)).to eq(1)
     expect(calculator.evaluate('10 + x', x: 'abc')).to be_nil
+    expect(calculator.evaluate('a/b', a: '10', b: '2')).to eq(5)
     expect(calculator.evaluate('t + 1*24*60*60', t: Time.local(2017, 1, 1))).to eq(Time.local(2017, 1, 2))
     expect(calculator.evaluate("2 | 3 * 9")).to eq (27)
     expect(calculator.evaluate("2 & 3 * 9")).to eq (2)


### PR DESCRIPTION
First of all thanks for your time again.

My specs started failing when I upgraded to Ruby 2.4.0. Debugging I noticed the problems just occur on division using string arguments.

The problems started on version 2.0.11 on commit bf44d25d6ee511f5ea9225eb808a5639af001797

Version 2.0.11
![test_a](https://cloud.githubusercontent.com/assets/410080/26399682/20ec6c02-407e-11e7-92a1-937ae1765114.png)

Version 2.0.10
![test_b](https://cloud.githubusercontent.com/assets/410080/26399685/2559a048-407e-11e7-8f19-d629c9b2275c.png)

The last commit is not necessary for the fix, I just extracted it to a private method since I believe validation is one thing and cast is other. Feel free to remove it if you think is too much abstraction.

@rubysolo Thank you for maintaining this gem. 💐 
