### PR TITLE
Assorted refactor

### DIFF
--- a/lib/dentaku/ast/arithmetic.rb
+++ b/lib/dentaku/ast/arithmetic.rb
@@ -71,14 +71,14 @@ module Dentaku
 
       def validate_operation(val)
         unless val.respond_to?(operator)
-          raise Dentaku::ArgumentError.new(:invalid_operator, operation: self.class, operator: operator),
-                "#{self.class} requires operands that respond to #{operator}"
+          raise Dentaku::ArgumentError.for(:invalid_operator, operation: self.class, operator: operator),
+                "#{ self.class } requires operands that respond to #{operator}"
         end
       end
 
       def validate_format(string)
         unless string =~ /\A-?\d+(\.\d+)?\z/
-          raise Dentaku::ArgumentError.new(:input_not_coercible_to_numeric, input: string),
+          raise Dentaku::ArgumentError.for(:invalid_value, value: string, for: BigDecimal),
                 "String input '#{string}' is not coercible to numeric"
         end
       end

--- a/lib/dentaku/ast/arithmetic.rb
+++ b/lib/dentaku/ast/arithmetic.rb
@@ -23,7 +23,7 @@ module Dentaku
       end
 
       def operator
-        raise "Not implemented"
+        raise NotImplementedError
       end
 
       def value(context={})

--- a/lib/dentaku/ast/arithmetic.rb
+++ b/lib/dentaku/ast/arithmetic.rb
@@ -71,13 +71,15 @@ module Dentaku
 
       def validate_operation(val)
         unless val.respond_to?(operator)
-          fail Dentaku::ArgumentError, "#{ self.class } requires operands that respond to #{ operator }"
+          raise Dentaku::ArgumentError.new(:invalid_operator, operation: self.class, operator: operator),
+                "#{self.class} requires operands that respond to #{operator}"
         end
       end
 
       def validate_format(string)
         unless string =~ /\A-?\d+(\.\d+)?\z/
-          fail Dentaku::ArgumentError, "String input '#{ string }' is not coercible to numeric"
+          raise Dentaku::ArgumentError.new(:input_not_coercible_to_numeric, input: string),
+                "String input '#{string}' is not coercible to numeric"
         end
       end
     end

--- a/lib/dentaku/ast/arithmetic.rb
+++ b/lib/dentaku/ast/arithmetic.rb
@@ -7,8 +7,14 @@ module Dentaku
     class Arithmetic < Operation
       def initialize(*)
         super
-        unless valid_left? && valid_right?
-          fail ParseError, "#{ self.class } requires numeric operands"
+
+        unless valid_left?
+          raise NodeError.new(:numeric, left.type, :left),
+                "#{self.class} requires numeric operands"
+        end
+        unless valid_right?
+          raise NodeError.new(:numeric, right.type, :right),
+                "#{self.class} requires numeric operands"
         end
       end
 
@@ -141,8 +147,13 @@ module Dentaku
           @right = left
         end
 
-        unless valid_left? && valid_right?
-          fail ParseError, "#{ self.class } requires numeric operand(s)"
+        unless valid_left?
+          raise NodeError.new(%i[numeric nil], left.type, :left),
+                "#{self.class} requires numeric operands or nil"
+        end
+        unless valid_right?
+          raise NodeError.new(:numeric, right.type, :right),
+                "#{self.class} requires numeric operands"
         end
       end
 

--- a/lib/dentaku/ast/combinators.rb
+++ b/lib/dentaku/ast/combinators.rb
@@ -5,8 +5,14 @@ module Dentaku
     class Combinator < Operation
       def initialize(*)
         super
-        unless valid_node?(left) && valid_node?(right)
-          fail ParseError, "#{ self.class } requires logical operands"
+
+        unless valid_node?(left)
+          raise NodeError.new(:logical, left.type, :left),
+                "#{self.class} requires logical operands"
+        end
+        unless valid_node?(right)
+          raise NodeError.new(:logical, right.type, :right),
+                "#{self.class} requires logical operands"
         end
       end
 

--- a/lib/dentaku/ast/function_registry.rb
+++ b/lib/dentaku/ast/function_registry.rb
@@ -5,7 +5,7 @@ module Dentaku
         name = function_name(name)
         return self[name] if has_key?(name)
         return default[name] if default.has_key?(name)
-        fail ParseError, "Undefined function #{ name }"
+        nil
       end
 
       def register(name, type, implementation)

--- a/lib/dentaku/ast/functions/and.rb
+++ b/lib/dentaku/ast/functions/and.rb
@@ -3,7 +3,7 @@ require_relative '../../exceptions'
 
 Dentaku::AST::Function.register(:and, :logical, lambda { |*args|
   if args.empty?
-    raise Dentaku::ArgumentError.new(
+    raise Dentaku::ArgumentError.for(
       :too_few_arguments,
       function_name: 'AND()', at_least: 1, given: 0
     ), 'AND() requires at least one argument'
@@ -16,7 +16,7 @@ Dentaku::AST::Function.register(:and, :logical, lambda { |*args|
     when FalseClass
       false
     else
-      raise Dentaku::ArgumentError.new(
+      raise Dentaku::ArgumentError.for(
         :incompatible_type,
         function_name: 'AND()', expect: :logical, actual: arg.class
       ), 'AND() requires arguments to be logical expressions'

--- a/lib/dentaku/ast/functions/and.rb
+++ b/lib/dentaku/ast/functions/and.rb
@@ -2,7 +2,12 @@ require_relative '../function'
 require_relative '../../exceptions'
 
 Dentaku::AST::Function.register(:and, :logical, lambda { |*args|
-  fail Dentaku::ArgumentError, 'AND() requires at least one argument' if args.empty?
+  if args.empty?
+    raise Dentaku::ArgumentError.new(
+      :too_few_arguments,
+      function_name: 'AND()', at_least: 1, given: 0
+    ), 'AND() requires at least one argument'
+  end
 
   args.all? do |arg|
     case arg
@@ -11,7 +16,10 @@ Dentaku::AST::Function.register(:and, :logical, lambda { |*args|
     when FalseClass
       false
     else
-      fail Dentaku::ArgumentError, 'AND() requires arguments to be logical expressions'
+      raise Dentaku::ArgumentError.new(
+        :incompatible_type,
+        function_name: 'AND()', expect: :logical, actual: arg.class
+      ), 'AND() requires arguments to be logical expressions'
     end
   end
 })

--- a/lib/dentaku/ast/functions/or.rb
+++ b/lib/dentaku/ast/functions/or.rb
@@ -3,7 +3,7 @@ require_relative '../../exceptions'
 
 Dentaku::AST::Function.register(:or, :logical, lambda { |*args|
   if args.empty?
-    raise Dentaku::ArgumentError.new(
+    raise Dentaku::ArgumentError.for(
       :too_few_arguments,
       function_name: 'OR()', at_least: 1, given: 0
     ), 'OR() requires at least one argument'
@@ -16,7 +16,7 @@ Dentaku::AST::Function.register(:or, :logical, lambda { |*args|
     when FalseClass
       false
     else
-      raise Dentaku::ArgumentError.new(
+      raise Dentaku::ArgumentError.for(
         :incompatible_type,
         function_name: 'AND()', expect: :logical, actual: arg.class
       ), 'AND() requires arguments to be logical expressions'

--- a/lib/dentaku/ast/functions/or.rb
+++ b/lib/dentaku/ast/functions/or.rb
@@ -2,7 +2,12 @@ require_relative '../function'
 require_relative '../../exceptions'
 
 Dentaku::AST::Function.register(:or, :logical, lambda { |*args|
-  fail Dentaku::ArgumentError, 'OR() requires at least one argument' if args.empty?
+  if args.empty?
+    raise Dentaku::ArgumentError.new(
+      :too_few_arguments,
+      function_name: 'OR()', at_least: 1, given: 0
+    ), 'OR() requires at least one argument'
+  end
 
   args.any? do |arg|
     case arg
@@ -11,7 +16,10 @@ Dentaku::AST::Function.register(:or, :logical, lambda { |*args|
     when FalseClass
       false
     else
-      fail Dentaku::ArgumentError, 'OR() requires arguments to be logical expressions'
+      raise Dentaku::ArgumentError.new(
+        :incompatible_type,
+        function_name: 'AND()', expect: :logical, actual: arg.class
+      ), 'AND() requires arguments to be logical expressions'
     end
   end
 })

--- a/lib/dentaku/ast/identifier.rb
+++ b/lib/dentaku/ast/identifier.rb
@@ -11,7 +11,8 @@ module Dentaku
 
       def value(context={})
         v = context.fetch(identifier) do
-          raise UnboundVariableError.new([identifier])
+          raise UnboundVariableError.new([identifier]),
+                "no value provided for variables: #{identifier}"
         end
 
         case v
@@ -23,7 +24,7 @@ module Dentaku
       end
 
       def dependencies(context={})
-        context.has_key?(identifier) ? dependencies_of(context[identifier]) : [identifier]
+        context.key?(identifier) ? dependencies_of(context[identifier]) : [identifier]
       end
 
       private

--- a/lib/dentaku/ast/negation.rb
+++ b/lib/dentaku/ast/negation.rb
@@ -3,7 +3,11 @@ module Dentaku
     class Negation < Arithmetic
       def initialize(node)
         @node = node
-        fail ParseError, "Negation requires numeric operand" unless valid_node?(node)
+
+        unless valid_node?(node)
+          raise NodeError.new(:numeric, left.type, :left),
+                "#{self.class} requires numeric operands"
+        end
       end
 
       def operator

--- a/lib/dentaku/bulk_expression_solver.rb
+++ b/lib/dentaku/bulk_expression_solver.rb
@@ -54,7 +54,7 @@ module Dentaku
             evaluate!(expressions[var_name], expressions.merge(r))
 
           r[var_name] = value
-        rescue Dentaku::UnboundVariableError, ZeroDivisionError => ex
+        rescue UnboundVariableError, Dentaku::ZeroDivisionError => ex
           ex.recipient_variable = var_name
           r[var_name] = block.call(ex)
         end

--- a/lib/dentaku/calculator.rb
+++ b/lib/dentaku/calculator.rb
@@ -40,7 +40,7 @@ module Dentaku
 
     def evaluate(expression, data={})
       evaluate!(expression, data)
-    rescue UnboundVariableError, ArgumentError
+    rescue UnboundVariableError, Dentaku::ArgumentError
       yield expression if block_given?
     end
 

--- a/lib/dentaku/calculator.rb
+++ b/lib/dentaku/calculator.rb
@@ -87,7 +87,7 @@ module Dentaku
       when Regexp
         @ast_cache.delete_if { |k,_| k =~ pattern }
       else
-        fail Dentaku::ArgumentError
+        raise ::ArgumentError
       end
     end
 

--- a/lib/dentaku/calculator.rb
+++ b/lib/dentaku/calculator.rb
@@ -21,10 +21,6 @@ module Dentaku
       Dentaku::AST::FunctionRegistry.default.register(name, type, body)
     end
 
-    def add_functions(fns)
-      fns.each { |(name, type, body)| add_function(name, type, body) }
-    end
-
     def add_function(name, type, body)
       @function_registry.register(name, type, body)
       self

--- a/lib/dentaku/calculator.rb
+++ b/lib/dentaku/calculator.rb
@@ -49,7 +49,10 @@ module Dentaku
         node = expression
         node = ast(node) unless node.is_a?(AST::Node)
         unbound = node.dependencies - memory.keys
-        raise UnboundVariableError.new(unbound) unless unbound.empty?
+        unless unbound.empty?
+          raise UnboundVariableError.new(unbound),
+                "no value provided for variables: #{unbound.join(', ')}"
+        end
         node.value(memory)
       end
     end

--- a/lib/dentaku/exceptions.rb
+++ b/lib/dentaku/exceptions.rb
@@ -39,6 +39,12 @@ module Dentaku
   end
 
   class ArgumentError < ::ArgumentError
+    attr_reader :reason, :meta
+
+    def initialize(reason, **meta)
+      @reason = reason
+      @meta = meta
+    end
   end
 
   class ZeroDivisionError < ::ZeroDivisionError

--- a/lib/dentaku/exceptions.rb
+++ b/lib/dentaku/exceptions.rb
@@ -6,7 +6,6 @@ module Dentaku
 
     def initialize(unbound_variables)
       @unbound_variables = unbound_variables
-      super("no value provided for variables: #{ unbound_variables.join(', ') }")
     end
   end
 

--- a/lib/dentaku/exceptions.rb
+++ b/lib/dentaku/exceptions.rb
@@ -10,6 +10,16 @@ module Dentaku
     end
   end
 
+  class NodeError < StandardError
+    attr_reader :child, :expect, :actual
+
+    def initialize(expect, actual, child)
+      @expect = Array(expect)
+      @actual = actual
+      @child = child
+    end
+  end
+
   class ParseError < StandardError
   end
 

--- a/lib/dentaku/exceptions.rb
+++ b/lib/dentaku/exceptions.rb
@@ -21,6 +21,12 @@ module Dentaku
   end
 
   class ParseError < StandardError
+    attr_reader :reason, :meta
+
+    def initialize(reason, **meta)
+      @reason = reason
+      @meta = meta
+    end
   end
 
   class TokenizerError < StandardError

--- a/lib/dentaku/exceptions.rb
+++ b/lib/dentaku/exceptions.rb
@@ -30,6 +30,12 @@ module Dentaku
   end
 
   class TokenizerError < StandardError
+    attr_reader :reason, :meta
+
+    def initialize(reason, **meta)
+      @reason = reason
+      @meta = meta
+    end
   end
 
   class ArgumentError < ::ArgumentError

--- a/lib/dentaku/exceptions.rb
+++ b/lib/dentaku/exceptions.rb
@@ -26,6 +26,23 @@ module Dentaku
       @reason = reason
       @meta = meta
     end
+
+    private_class_method :new
+
+    VALID_REASONS = %i[
+      node_invalid too_few_operands undefined_function
+      unprocessed_token unknown_case_token unbalanced_bracket
+      unbalanced_parenthesis unknown_grouping_token not_implemented_token_category
+      invalid_statement
+    ].freeze
+
+    def self.for(reason, **meta)
+      unless VALID_REASONS.include?(reason)
+        raise ::ArgumentError, "Unhandled #{reason}"
+      end
+
+      new reason, meta
+    end
   end
 
   class TokenizerError < StandardError
@@ -35,6 +52,21 @@ module Dentaku
       @reason = reason
       @meta = meta
     end
+
+    private_class_method :new
+
+    VALID_REASONS = %i[
+      parse_error too_many_opening_parentheses too_many_closing_parentheses
+      unexpected_zero_width_match
+    ].freeze
+
+    def self.for(reason, **meta)
+      unless VALID_REASONS.include?(reason)
+        raise ::ArgumentError, "Unhandled #{reason}"
+      end
+
+      new reason, meta
+    end
   end
 
   class ArgumentError < ::ArgumentError
@@ -43,6 +75,21 @@ module Dentaku
     def initialize(reason, **meta)
       @reason = reason
       @meta = meta
+    end
+
+    private_class_method :new
+
+    VALID_REASONS = %i[
+      invalid_operator invalid_value too_few_arguments
+      too_much_arguments incompatible_type
+    ].freeze
+
+    def self.for(reason, **meta)
+      unless VALID_REASONS.include?(reason)
+        raise ::ArgumentError, "Unhandled #{reason}"
+      end
+
+      new reason, meta
     end
   end
 

--- a/lib/dentaku/parser.rb
+++ b/lib/dentaku/parser.rb
@@ -296,7 +296,7 @@ module Dentaku
           raise ::ArgumentError, "Unhandled #{reason}"
         end
 
-      raise ParseError.new(reason, meta), message
+      raise ParseError.for(reason, meta), message
     end
   end
 end

--- a/lib/dentaku/parser.rb
+++ b/lib/dentaku/parser.rb
@@ -64,8 +64,13 @@ module Dentaku
           output.push AST::Nil.new
 
         when :function
+          func = function(token)
+          if func.nil?
+            fail ParseError, "Undefined function #{ token.value }"
+          end
+
           arities.push 0
-          operations.push function(token)
+          operations.push func
 
         when :case
           case token.value

--- a/lib/dentaku/parser.rb
+++ b/lib/dentaku/parser.rb
@@ -21,6 +21,8 @@ module Dentaku
       operator = operations.pop
       operator.peek(output)
       output.push operator.new(*get_args(operator.arity || count))
+    rescue NodeError => e
+      raise ParseError, "#{ operator } requires #{e.expect.join(', ')} operands, but got #{ e.actual }"
     end
 
     def parse

--- a/lib/dentaku/token.rb
+++ b/lib/dentaku/token.rb
@@ -16,6 +16,10 @@ module Dentaku
       raw_value.to_s.length
     end
 
+    def empty?
+      length.zero?
+    end
+
     def grouping?
       is?(:grouping)
     end

--- a/lib/dentaku/tokenizer.rb
+++ b/lib/dentaku/tokenizer.rb
@@ -75,7 +75,7 @@ module Dentaku
           raise ::ArgumentError, "Unhandled #{reason}"
         end
 
-      raise TokenizerError.new(reason, meta), message
+      raise TokenizerError.for(reason, meta), message
     end
   end
 end

--- a/spec/ast/addition_spec.rb
+++ b/spec/ast/addition_spec.rb
@@ -17,7 +17,7 @@ describe Dentaku::AST::Addition do
   it 'requires numeric operands' do
     expect {
       described_class.new(five, t)
-    }.to raise_error(Dentaku::ParseError, /requires numeric operands/)
+    }.to raise_error(Dentaku::NodeError, /requires numeric operands/)
 
     expression = Dentaku::AST::Multiplication.new(five, five)
     group = Dentaku::AST::Grouping.new(expression)

--- a/spec/ast/and_spec.rb
+++ b/spec/ast/and_spec.rb
@@ -17,7 +17,7 @@ describe Dentaku::AST::And do
   it 'requires logical operands' do
     expect {
       described_class.new(t, five)
-    }.to raise_error(Dentaku::ParseError, /requires logical operands/)
+    }.to raise_error(Dentaku::NodeError, /requires logical operands/)
 
     expression = Dentaku::AST::LessThanOrEqual.new(five, five)
     expect {

--- a/spec/ast/division_spec.rb
+++ b/spec/ast/division_spec.rb
@@ -17,7 +17,7 @@ describe Dentaku::AST::Division do
   it 'requires numeric operands' do
     expect {
       described_class.new(five, t)
-    }.to raise_error(Dentaku::ParseError, /requires numeric operands/)
+    }.to raise_error(Dentaku::NodeError, /requires numeric operands/)
 
     expression = Dentaku::AST::Multiplication.new(five, five)
     group = Dentaku::AST::Grouping.new(expression)

--- a/spec/ast/function_spec.rb
+++ b/spec/ast/function_spec.rb
@@ -10,12 +10,6 @@ describe Dentaku::AST::Function do
     expect(described_class).to respond_to(:get)
   end
 
-  it 'raises an exception when trying to access an undefined function' do
-    expect {
-      described_class.get("flarble")
-    }.to raise_error(Dentaku::ParseError, /undefined function/i)
-  end
-
   it 'registers a custom function' do
     described_class.register("flarble", :string, -> { "flarble" })
     expect { described_class.get("flarble") }.not_to raise_error

--- a/spec/exceptions_spec.rb
+++ b/spec/exceptions_spec.rb
@@ -4,6 +4,6 @@ require 'dentaku/exceptions'
 describe Dentaku::UnboundVariableError do
   it 'includes variable name(s) in message' do
     exception = described_class.new(['length'])
-    expect(exception.message).to match /length/
+    expect(exception.unbound_variables).to include('length')
   end
 end

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -171,6 +171,14 @@ describe Dentaku::Parser do
         described_class.new([this, also]).parse
       }.to raise_error(Dentaku::ParseError)
     end
+
+    it 'raises an exception when trying to access an undefined function' do
+      fn = Dentaku::Token.new(:function, 'non_exists_func')
+
+      expect {
+        described_class.new([fn]).parse
+      }.to raise_error(Dentaku::ParseError)
+    end
   end
 
   it "evaluates explicit 'NULL' as a Nil" do


### PR DESCRIPTION
Dentaku is an awesome gem!

I'm working on a prototype app for researching that can define a form with many fields (it support many datatypes) and give a expression to evaluate value.

the demo is in <https://dentaku-calculator.herokuapp.com/> 
source code in <https://github.com/jasl/dentaku_calculator>
Dentaku relates is in <https://github.com/jasl/dentaku_calculator/blob/master/app/lib/virtual_model.rb#L8-L34>

define a form with fields
![image](https://user-images.githubusercontent.com/1024162/28700497-adf560b8-7382-11e7-995e-79372241c6fd.png)

fill fields and expression
![image](https://user-images.githubusercontent.com/1024162/28700506-c6970aa4-7382-11e7-8b20-c22bf1cbf9e1.png)

integration with model validation (support i18n)
![image](https://user-images.githubusercontent.com/1024162/28700643-a7940840-7383-11e7-8084-6eff19395286.png)
![image](https://user-images.githubusercontent.com/1024162/28700656-b4026fea-7383-11e7-8916-9c8d2354ac75.png)

calculate
![image](https://user-images.githubusercontent.com/1024162/28700663-cd9c9a3e-7383-11e7-9af0-093b3510c217.png)

It's based on Dentaku, but I do some refactor to support my needs, the major change (but not break compatibility) is classified errors and stored some meta to helping top-level given user a friendly tips.

So I give this PR for discussion, is these changes good to Dentaku? how can I polish these changes? English isn't my mother tongue, the reason of errors follows practice of English?
