### PR TITLE
Allow decimals with no leading zero

### DIFF
--- a/lib/dentaku/ast/arithmetic.rb
+++ b/lib/dentaku/ast/arithmetic.rb
@@ -77,7 +77,7 @@ module Dentaku
       end
 
       def validate_format(string)
-        unless string =~ /\A-?\d+(\.\d+)?\z/
+        unless string =~ /\A-?\d*(\.\d+)?\z/
           raise Dentaku::ArgumentError.for(:invalid_value, value: string, for: BigDecimal),
                 "String input '#{string}' is not coercible to numeric"
         end

--- a/spec/calculator_spec.rb
+++ b/spec/calculator_spec.rb
@@ -32,6 +32,7 @@ describe Dentaku::Calculator do
     expect(calculator.evaluate('0.253/0.253')).to eq(1)
     expect(calculator.evaluate('0.253/d', d: 0.253)).to eq(1)
     expect(calculator.evaluate('10 + x', x: 'abc')).to be_nil
+    expect(calculator.evaluate('x * y', x: '.123', y: '100')).to eq(12.3)
     expect(calculator.evaluate('a/b', a: '10', b: '2')).to eq(5)
     expect(calculator.evaluate('t + 1*24*60*60', t: Time.local(2017, 1, 1))).to eq(Time.local(2017, 1, 2))
     expect(calculator.evaluate("2 | 3 * 9")).to eq (27)


### PR DESCRIPTION
When variables are passed in as strings, you can have a valid decimal with no leading
zero (e.g. `'.123'` instead of `'0.123'`)