### PR TITLE
Added "expand" option to solve, and added a complex spec for nested hashes / array

### DIFF
--- a/lib/dentaku/bulk_expression_solver.rb
+++ b/lib/dentaku/bulk_expression_solver.rb
@@ -11,16 +11,22 @@ module Dentaku
       @calculator = calculator
     end
 
-    def solve!
-      solve(&raise_exception_handler)
+    def solve!(options = {})
+      solve(options, &raise_exception_handler)
     end
 
-    def solve(&block)
+    def solve(options = {}, &block)
       error_handler = block || return_undefined_handler
       results = load_results(&error_handler)
 
       expression_hash.each_with_object({}) do |(k, _), r|
-        r[k] = results[k.to_s]
+        if options[:expand]
+          hash_levels = k.to_s.split('.')
+          child_hash = hash_levels[0...-1].reduce(r) { |h, n| h[n] ||= {} }
+          child_hash[hash_levels.last] = results[k.to_s]
+        else
+          r[k] = results[k.to_s]
+        end
       end
     end
 

--- a/lib/dentaku/calculator.rb
+++ b/lib/dentaku/calculator.rb
@@ -59,12 +59,12 @@ module Dentaku
       end
     end
 
-    def solve!(expression_hash)
-      BulkExpressionSolver.new(expression_hash, self).solve!
+    def solve!(expression_hash, options = {})
+      BulkExpressionSolver.new(expression_hash, self).solve!(options)
     end
 
-    def solve(expression_hash, &block)
-      BulkExpressionSolver.new(expression_hash, self).solve(&block)
+    def solve(expression_hash, options = {}, &block)
+      BulkExpressionSolver.new(expression_hash, self).solve(options, &block)
     end
 
     def dependencies(expression)

--- a/spec/bulk_expression_solver_spec.rb
+++ b/spec/bulk_expression_solver_spec.rb
@@ -37,6 +37,45 @@ RSpec.describe Dentaku::BulkExpressionSolver do
       solver = described_class.new(expressions, calculator.store("x" => 3))
       expect(solver.solve!).to eq({ "the value of x, incremented" => 4 })
     end
+
+    it "evaluates expressions in hashes and arrays, and expands the results" do
+      calculator.store(
+        fruit_quantities: {
+          apple: 5,
+          pear: 9
+        },
+        fruit_prices: {
+          apple: 1.66,
+          pear: 2.50
+        }
+      )
+      expressions = {
+        weekly_budget: {
+          fruit:  "weekly_budget.apples + weekly_budget.pears",
+          apples: "fruit_quantities.apple * discounted_fruit_prices.apple",
+          pears:  "fruit_quantities.pear * discounted_fruit_prices.pear",
+        },
+        discounted_fruit_prices: {
+          apple: "round(fruit_prices.apple * discounts[0], 2)",
+          pear: "round(fruit_prices.pear * discounts[1], 2)"
+        },
+        discounts: ["0.4 * 2", "0.3 * 2"],
+      }
+      solver = described_class.new(expressions, calculator)
+
+      expect(solver.solve!(expand: true)).to eq(
+        "weekly_budget" => {
+          "fruit" => 20.15,
+          "apples" => 6.65,
+          "pears" => 13.50
+        },
+        "discounted_fruit_prices" => {
+          "apple" => 1.33,
+          "pear" => 1.50
+        },
+        "discounts" => [0.8, 0.6]
+      )
+    end
   end
 
   describe "#solve" do


### PR DESCRIPTION
I added an `:expand` to solve, which converts the `foo.bar` keys back into hashes (e.g. `{ 'foo' => 'bar' }`.

I also added a more complex spec which tests the `expand` option with nested hashes and arrays.