### PR TITLE
Flatten all arguments to min, max, sum, and Math functions

### DIFF
--- a/lib/dentaku/ast/functions/max.rb
+++ b/lib/dentaku/ast/functions/max.rb
@@ -1,5 +1,5 @@
 require_relative '../function'
 
 Dentaku::AST::Function.register(:max, :numeric, ->(*args) {
-  args.map { |arg| Dentaku::AST::Function.numeric(arg) }.max
+  args.flatten.map { |arg| Dentaku::AST::Function.numeric(arg) }.max
 })

--- a/lib/dentaku/ast/functions/min.rb
+++ b/lib/dentaku/ast/functions/min.rb
@@ -1,5 +1,5 @@
 require_relative '../function'
 
 Dentaku::AST::Function.register(:min, :numeric, ->(*args) {
-  args.map { |arg| Dentaku::AST::Function.numeric(arg) }.min
+  args.flatten.map { |arg| Dentaku::AST::Function.numeric(arg) }.min
 })

--- a/lib/dentaku/ast/functions/ruby_math.rb
+++ b/lib/dentaku/ast/functions/ruby_math.rb
@@ -3,6 +3,6 @@ require_relative '../function'
 
 Math.methods(false).each do |method|
   Dentaku::AST::Function.register(method, :numeric, lambda { |*args|
-    Math.send(method, *args.map { |arg| Dentaku::AST::Function.numeric(arg) })
+    Math.send(method, *args.flatten.map { |arg| Dentaku::AST::Function.numeric(arg) })
   })
 end

--- a/lib/dentaku/ast/functions/sum.rb
+++ b/lib/dentaku/ast/functions/sum.rb
@@ -8,5 +8,5 @@ Dentaku::AST::Function.register(:sum, :numeric, ->(*args) {
     ), 'SUM() requires at least one argument'
   end
 
-  args.map { |arg| Dentaku::AST::Function.numeric(arg) }.reduce(0, :+)
+  args.flatten.map { |arg| Dentaku::AST::Function.numeric(arg) }.reduce(0, :+)
 })

--- a/spec/ast/max_spec.rb
+++ b/spec/ast/max_spec.rb
@@ -12,4 +12,9 @@ describe 'Dentaku::AST::Function::Max' do
     result = Dentaku('MAX(1, x, 1.8)', x: '2.3')
     expect(result).to eq 2.3
   end
+
+  it 'returns the largest value even if an Array is passed' do
+    result = Dentaku('MAX(1, x, 1.8)', x: [1.5, 2.3, 1.7])
+    expect(result).to eq 2.3
+  end
 end

--- a/spec/ast/min_spec.rb
+++ b/spec/ast/min_spec.rb
@@ -12,4 +12,9 @@ describe 'Dentaku::AST::Function::Min' do
     result = Dentaku('MIN(1, x, 1.8)', x: '0.3')
     expect(result).to eq 0.3
   end
+
+  it 'returns the smallest value even if an Array is passed' do
+    result = Dentaku('MIN(1, x, 1.8)', x: [1.5, 0.3, 1.7])
+    expect(result).to eq 0.3
+  end
 end

--- a/spec/ast/sum_spec.rb
+++ b/spec/ast/sum_spec.rb
@@ -18,6 +18,11 @@ describe 'Dentaku::AST::Function::Sum' do
     expect(result).to eq 5.1
   end
 
+  it 'returns the sum even if an array is passed' do
+    result = Dentaku('SUM(1, x, 2.3)', x: [4, 5])
+    expect(result).to eq 12.3
+  end
+
   it 'returns the sum of nested sums' do
     result = Dentaku('SUM(1, x, SUM(4, 5))', x: '2.3')
     expect(result).to eq 12.3


### PR DESCRIPTION
This adds support for arguments that are arrays, and flattens everything into a single list of arguments. Really useful for `min`, `max` and `sum`.

This is just adding support for something that would previously cause a crash, so there's no backwards compatibility issues to worry about.