### PR TITLE
Fix evalutating expressions including percentage operator(modulo with…

### DIFF
--- a/lib/dentaku/ast/arithmetic.rb
+++ b/lib/dentaku/ast/arithmetic.rb
@@ -159,6 +159,14 @@ module Dentaku
         end
       end
 
+      def dependencies(context = {})
+        if percent?
+          @right.dependencies(context)
+        else
+          super
+        end
+      end
+
       def percent?
         left.nil?
       end

--- a/spec/calculator_spec.rb
+++ b/spec/calculator_spec.rb
@@ -38,6 +38,7 @@ describe Dentaku::Calculator do
     expect(calculator.evaluate('t + 1*24*60*60', t: Time.local(2017, 1, 1))).to eq(Time.local(2017, 1, 2))
     expect(calculator.evaluate("2 | 3 * 9")).to eq (27)
     expect(calculator.evaluate("2 & 3 * 9")).to eq (2)
+    expect(calculator.evaluate("5%")).to eq (0.05)
   end
 
   describe 'evaluate' do


### PR DESCRIPTION
… arity == 1)

It caused crashes in ```/lib/dentaku/ast/operation.rb:14:in `dependencies'``` for expressions like ```5%```