### PR TITLE
Prepare gem for usage with Ruby 2.6.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.6
   # RuboCop has a bunch of cops enabled by default. This setting tells RuboCop
   # to ignore them, so only the ones explicitly set in this file are enabled.
   DisabledByDefault: true
@@ -110,7 +110,7 @@ Style/UnneededPercentQ:
 
 # Align `end` with the matching keyword or starting expression except for
 # assignments, where it should be aligned with the LHS.
-Lint/EndAlignment:
+Layout/EndAlignment:
   Enabled: true
   EnforcedStyleAlignWith: variable
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
   - 2.3.6
   - 2.4.3
   - 2.5.0
+  - 2.6.0
 before_install:
   - gem update bundler
   - gem update --system

--- a/lib/dentaku/ast/arithmetic.rb
+++ b/lib/dentaku/ast/arithmetic.rb
@@ -40,7 +40,7 @@ module Dentaku
       end
 
       def numeric(val, prefer_integer)
-        v = BigDecimal.new(val, Float::DIG + 1)
+        v = BigDecimal(val, Float::DIG + 1)
         v = v.to_i if prefer_integer && v.frac.zero?
         v
       rescue ::TypeError

--- a/lib/dentaku/ast/function.rb
+++ b/lib/dentaku/ast/function.rb
@@ -38,7 +38,7 @@ module Dentaku
 
         if value.is_a?(::String)
           number = value[/\A-?\d*\.?\d+\z/]
-          return number.include?('.') ? ::BigDecimal.new(number, DIG) : number.to_i if number
+          return number.include?('.') ? BigDecimal(number, DIG) : number.to_i if number
         end
 
         raise Dentaku::ArgumentError.for(:incompatible_type, value: value, for: Numeric),

--- a/lib/dentaku/token_scanner.rb
+++ b/lib/dentaku/token_scanner.rb
@@ -91,7 +91,7 @@ module Dentaku
 
       def numeric
         new(:numeric, '((?:\d+(\.\d+)?|\.\d+)(?:(e|E)(\+|-)?\d+)?)\b', lambda { |raw|
-          raw =~ /\./ ? BigDecimal.new(raw) : raw.to_i
+          raw =~ /\./ ? BigDecimal(raw) : raw.to_i
         })
       end
 

--- a/spec/calculator_spec.rb
+++ b/spec/calculator_spec.rb
@@ -394,7 +394,7 @@ describe Dentaku::Calculator do
     it 'include ROUND' do
       expect(calculator.evaluate('round(8.2)')).to eq(8)
       expect(calculator.evaluate('round(8.8)')).to eq(9)
-      expect(calculator.evaluate('round(8.75, 1)')).to eq(BigDecimal.new('8.8'))
+      expect(calculator.evaluate('round(8.75, 1)')).to eq(BigDecimal('8.8'))
 
       expect(calculator.evaluate('ROUND(apples * 0.93)', apples: 10)).to eq(9)
     end
@@ -410,7 +410,7 @@ describe Dentaku::Calculator do
     it 'evaluates functions with negative numbers' do
       expect(calculator.evaluate('if (-1 < 5, -1, 5)')).to eq(-1)
       expect(calculator.evaluate('if (-1 = -1, -1, 5)')).to eq(-1)
-      expect(calculator.evaluate('round(-1.23, 1)')).to eq(BigDecimal.new('-1.2'))
+      expect(calculator.evaluate('round(-1.23, 1)')).to eq(BigDecimal('-1.2'))
       expect(calculator.evaluate('NOT(some_boolean) AND -1 > 3', some_boolean: true)).to be_falsey
     end
 

--- a/spec/token_scanner_spec.rb
+++ b/spec/token_scanner_spec.rb
@@ -3,7 +3,7 @@ require 'dentaku/token_scanner'
 describe Dentaku::TokenScanner do
   let(:whitespace) { described_class.new(:whitespace, '\s') }
   let(:numeric)    { described_class.new(:numeric,    '(\d+(\.\d+)?|\.\d+)',
-    ->(raw) { raw =~ /\./ ? BigDecimal.new(raw) : raw.to_i })
+    ->(raw) { raw =~ /\./ ? BigDecimal(raw) : raw.to_i })
   }
   let(:custom)     { described_class.new(:identifier, '#\w+\b',
     ->(raw) { raw.gsub('#', '').to_sym })

--- a/spec/tokenizer_spec.rb
+++ b/spec/tokenizer_spec.rb
@@ -243,22 +243,22 @@ describe Dentaku::Tokenizer do
       tokens = tokenizer.tokenize('round(8.2)')
       expect(tokens.length).to eq(4)
       expect(tokens.map(&:category)).to eq([:function, :grouping, :numeric, :grouping])
-      expect(tokens.map(&:value)).to eq([:round, :open, BigDecimal.new('8.2'), :close])
+      expect(tokens.map(&:value)).to eq([:round, :open, BigDecimal('8.2'), :close])
 
       tokens = tokenizer.tokenize('round(8.75, 1)')
       expect(tokens.length).to eq(6)
       expect(tokens.map(&:category)).to eq([:function, :grouping, :numeric, :grouping, :numeric, :grouping])
-      expect(tokens.map(&:value)).to eq([:round, :open, BigDecimal.new('8.75'), :comma, 1, :close])
+      expect(tokens.map(&:value)).to eq([:round, :open, BigDecimal('8.75'), :comma, 1, :close])
 
       tokens = tokenizer.tokenize('ROUNDUP(8.2)')
       expect(tokens.length).to eq(4)
       expect(tokens.map(&:category)).to eq([:function, :grouping, :numeric, :grouping])
-      expect(tokens.map(&:value)).to eq([:roundup, :open, BigDecimal.new('8.2'), :close])
+      expect(tokens.map(&:value)).to eq([:roundup, :open, BigDecimal('8.2'), :close])
 
       tokens = tokenizer.tokenize('RoundDown(8.2)')
       expect(tokens.length).to eq(4)
       expect(tokens.map(&:category)).to eq([:function, :grouping, :numeric, :grouping])
-      expect(tokens.map(&:value)).to eq([:rounddown, :open, BigDecimal.new('8.2'), :close])
+      expect(tokens.map(&:value)).to eq([:rounddown, :open, BigDecimal('8.2'), :close])
     end
 
     it 'include NOT' do


### PR DESCRIPTION
This PR makes a few small adjustments to improve the way the gem works when running in Ruby 2.6.0:

- In Ruby 2.6.0, this gem generates a lot of deprecation notices to the console complaining about the usage of the `BigDecimal.new` constructor (e.g. `.../dentaku/lib/dentaku/ast/function.rb:41: warning: BigDecimal.new is deprecated; use BigDecimal() method instead.`). This PR updates all occurrences of `BigDecimal.new(..)` to `BigDecimal(..)` to resolve the issue.
- Add Ruby 2.6.0 to the CI configuration.
- Update Rubocop config to expect 2.6 syntax. Also fix reference to `Layout/EndAlignment` cop in the configuration (previously it was incorrectly namespaced under `Lint` - Rubocop was always outputting a warning about this when it was run).