### PR TITLE
Fixes #180: Nested CASE problem

### DIFF
--- a/lib/dentaku/parser.rb
+++ b/lib/dentaku/parser.rb
@@ -131,7 +131,8 @@ module Dentaku
               subparser = Parser.new(
                 inner_case_inputs,
                 operations: [AST::Case],
-                arities: [0]
+                arities: [0],
+                function_registry: @function_registry
               )
               subparser.parse
               output.concat(subparser.output)


### PR DESCRIPTION
The subparser instance needs a reference to the functions registry in order to use custom functions inside nested CASE statements