### PR TITLE
Attr reader for Negation#node

### DIFF
--- a/lib/dentaku/ast/negation.rb
+++ b/lib/dentaku/ast/negation.rb
@@ -1,6 +1,8 @@
 module Dentaku
   module AST
     class Negation < Arithmetic
+      attr_reader :node
+
       def initialize(node)
         @node = node
 

--- a/lib/dentaku/ast/negation.rb
+++ b/lib/dentaku/ast/negation.rb
@@ -5,7 +5,7 @@ module Dentaku
         @node = node
 
         unless valid_node?(node)
-          raise NodeError.new(:numeric, left.type, :left),
+          raise NodeError.new(:numeric, node.type, :node),
                 "#{self.class} requires numeric operands"
         end
       end

--- a/spec/ast/addition_spec.rb
+++ b/spec/ast/addition_spec.rb
@@ -9,6 +9,12 @@ describe Dentaku::AST::Addition do
 
   let(:t)    { Dentaku::AST::Numeric.new Dentaku::Token.new(:logical, true) }
 
+  it 'allows access to its sub-trees' do
+    node = described_class.new(five, six)
+    expect(node.left).to eq(five)
+    expect(node.right).to eq(six)
+  end
+
   it 'performs addition' do
     node = described_class.new(five, six)
     expect(node.value).to eq(11)

--- a/spec/ast/arithmetic_spec.rb
+++ b/spec/ast/arithmetic_spec.rb
@@ -15,6 +15,7 @@ describe Dentaku::AST::Arithmetic do
     expect(sub(one, two)).to eq(-1)
     expect(mul(one, two)).to eq(2)
     expect(div(one, two)).to eq(0.5)
+    expect(neg(one)).to eq(-1)
   end
 
   it 'performs an arithmetic operation with one numeric operand and one string operand' do
@@ -34,6 +35,7 @@ describe Dentaku::AST::Arithmetic do
     expect(sub(x, y)).to eq(-1)
     expect(mul(x, y)).to eq(2)
     expect(div(x, y)).to eq(0.5)
+    expect(neg(x)).to eq(-1)
   end
 
   private
@@ -52,5 +54,9 @@ describe Dentaku::AST::Arithmetic do
 
   def div(left, right)
     Dentaku::AST::Division.new(left, right).value(ctx)
+  end
+
+  def neg(node)
+    Dentaku::AST::Negation.new(node).value(ctx)
   end
 end

--- a/spec/ast/division_spec.rb
+++ b/spec/ast/division_spec.rb
@@ -9,6 +9,12 @@ describe Dentaku::AST::Division do
 
   let(:t)    { Dentaku::AST::Numeric.new Dentaku::Token.new(:logical, true) }
 
+  it 'allows access to its sub-trees' do
+    node = described_class.new(five, six)
+    expect(node.left).to eq(five)
+    expect(node.right).to eq(six)
+  end
+
   it 'performs division' do
     node = described_class.new(five, six)
     expect(node.value.round(4)).to eq(0.8333)

--- a/spec/ast/negation_spec.rb
+++ b/spec/ast/negation_spec.rb
@@ -7,6 +7,11 @@ describe Dentaku::AST::Negation do
   let(:five) { Dentaku::AST::Logical.new Dentaku::Token.new(:numeric, 5) }
   let(:t)    { Dentaku::AST::Numeric.new Dentaku::Token.new(:logical, true) }
 
+  it 'allows access to its sub-node' do
+    node = described_class.new(five)
+    expect(node.node).to eq(five)
+  end
+
   it 'performs negation' do
     node = described_class.new(five)
     expect(node.value).to eq(-5)

--- a/spec/ast/negation_spec.rb
+++ b/spec/ast/negation_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+require 'dentaku/ast/arithmetic'
+
+require 'dentaku/token'
+
+describe Dentaku::AST::Negation do
+  let(:five) { Dentaku::AST::Logical.new Dentaku::Token.new(:numeric, 5) }
+  let(:t)    { Dentaku::AST::Numeric.new Dentaku::Token.new(:logical, true) }
+
+  it 'performs negation' do
+    node = described_class.new(five)
+    expect(node.value).to eq(-5)
+  end
+
+  it 'requires numeric operands' do
+    expect {
+      described_class.new(t)
+    }.to raise_error(Dentaku::NodeError, /requires numeric operands/)
+
+    expression = Dentaku::AST::Negation.new(five)
+    group = Dentaku::AST::Grouping.new(expression)
+
+    expect {
+      described_class.new(group)
+    }.not_to raise_error
+  end
+end


### PR DESCRIPTION
This PR:

* Adds an attr reader for `@node` in the Negation operation, so that property can be read like `left` and `right` in binary operations
* Fleshes out spec coverage for Negation class as well as for attr readers in other Operations
* Fixes a bug that this uncovered in how Negation errors when given non-numeric operators

The `node` attr reader is needed if you want to visit an AST in order to transform it somehow.