### PR TITLE
Arithmetic: speed up node validation

### DIFF
--- a/lib/dentaku/ast/access.rb
+++ b/lib/dentaku/ast/access.rb
@@ -22,6 +22,10 @@ module Dentaku
       def dependencies(context = {})
         @structure.dependencies(context) + @index.dependencies(context)
       end
+
+      def type
+        nil
+      end
     end
   end
 end

--- a/lib/dentaku/ast/arithmetic.rb
+++ b/lib/dentaku/ast/arithmetic.rb
@@ -50,7 +50,7 @@ module Dentaku
       end
 
       def valid_node?(node)
-        node && (node.dependencies.any? || node.type == :numeric)
+        node && (node.type == :numeric || node.dependencies.any?)
       end
 
       def valid_left?

--- a/lib/dentaku/ast/array.rb
+++ b/lib/dentaku/ast/array.rb
@@ -18,6 +18,10 @@ module Dentaku
       def dependencies(context = {})
         @elements.flat_map { |el| el.dependencies(context) }
       end
+
+      def type
+        nil
+      end
     end
   end
 end

--- a/lib/dentaku/ast/node.rb
+++ b/lib/dentaku/ast/node.rb
@@ -15,6 +15,10 @@ module Dentaku
       def dependencies(context = {})
         []
       end
+
+      def type
+        nil
+      end
     end
   end
 end


### PR DESCRIPTION
On large expressions, `node.dependencies` can take up a lot of time. On
some conditions, parsing a string can spend approximately all its time
traversing the dependency tree, validating if the left/right nodes are
ok.

We can avoid a lot of that time by first validating the type. This way
for example, for an expression like: '1 + 2 * 2', the Addition operator
does not need to traverse the Multiplication operator dependencies to
determine the node is indeed valid.

In order to simplify type checking, we add the type attribute to all
Node-like classes that don't inherit from Node.

Call stack before:

![image](https://user-images.githubusercontent.com/1322013/65636336-7582e580-dfb8-11e9-869d-b3d07ce80735.png)

Call stack after;

![image](https://user-images.githubusercontent.com/1322013/65636680-1e314500-dfb9-11e9-8d6c-334688949aac.png)

