### PR TITLE
Define for every function a properly named class that represents it

### DIFF
--- a/spec/external_function_spec.rb
+++ b/spec/external_function_spec.rb
@@ -59,6 +59,20 @@ describe Dentaku::Calculator do
       expect(calculator.evaluate("hey!()")).to eq("hey!")
     end
 
+    it 'defines for a given function a properly named class that represents it' do
+      calculator = described_class.new
+      calculator.add_function(:ho, :string, -> {})
+      expect(Dentaku::AST.const_defined?("Ho")).to eq(true)
+    end
+
+    it 'does not define class if it already exists for a given function' do
+      calculator = described_class.new
+      expect(Dentaku::AST.const_defined?("And")).to eq(true)
+      expect {
+        calculator.add_function(:and, :logical, -> {})
+      }.not_to change { Dentaku::AST::And.object_id }
+    end
+
     it 'does not store functions across all calculators' do
       calculator1 = Dentaku::Calculator.new
       calculator1.add_function(:my_function, :numeric, ->(x) { 2 * x + 1 })


### PR DESCRIPTION
Thanks to that solution there is a possibility to marshalize precompiled to AST expressions that include functions like `max`, `sum`, `round` etc.
The only exceptions are when there is already defined class for a given function (e.g. :and) or there is an uncommon function's name given, e.g. "bang!" function. In that case, we cannot create a class with such a name, so there is an anonymous class created like it has been done so far.

Usage example:
```
irb(main):003:0> expression = 'MAX(1, 2)'
=> "MAX(1, 2)"
irb(main):004:0> ast = Dentaku.calculator.ast(expression)
=> #<Dentaku::AST::Max:0x00007ffd828842d0 @args=[#<Dentaku::AST::Numeric:0x00007ffd82884398 @value=1, @type=:numeric>, #<Dentaku::AST::Numeric:0x00007ffd82884370 @value=2, @type=:numeric>]>
irb(main):005:0> marshalized_ast = Marshal.dump(ast)
=> "\x04\bo:\x16Dentaku::AST::Max\x06:\n@args[\ao:\x1ADentaku::AST::Numeric\a:\v@valuei\x06:\n@type:\fnumerico;\a\a;\bi\a;\t;\n"
irb(main):006:0> Marshal.load(marshalized_ast)
=> #<Dentaku::AST::Max:0x00007ffd83010f80 @args=[#<Dentaku::AST::Numeric:0x00007ffd83010ee0 @value=1, @type=:numeric>, #<Dentaku::AST::Numeric:0x00007ffd83010e40 @value=2, @type=:numeric>]>
```

ref: https://github.com/rubysolo/dentaku/issues/198