### PR TITLE
Parse intermediate values out of given variables to use as well

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -97,7 +97,7 @@ Layout/Tab:
   Enabled: true
 
 # Blank lines should not have any spaces.
-Layout/TrailingBlankLines:
+Layout/TrailingEmptyLines:
   Enabled: true
 
 # No trailing whitespace.

--- a/lib/dentaku/calculator.rb
+++ b/lib/dentaku/calculator.rb
@@ -119,7 +119,7 @@ module Dentaku
       restore = Hash[memory]
 
       if value.nil?
-        key_or_hash = FlatHash.from_hash(key_or_hash) if nested_data_support
+        key_or_hash = FlatHash.from_hash_with_intermediates(key_or_hash) if nested_data_support
         key_or_hash.each do |key, val|
           memory[standardize_case(key.to_s)] = val
         end

--- a/lib/dentaku/flat_hash.rb
+++ b/lib/dentaku/flat_hash.rb
@@ -6,6 +6,13 @@ module Dentaku
       flatten_keys(acc)
     end
 
+    def self.from_hash_with_intermediates(h, key = [], acc = {})
+      acc.update(key => h) unless key.empty?
+      return unless h.is_a? Hash
+      h.each { |k, v| from_hash_with_intermediates(v, key + [k], acc) }
+      flatten_keys(acc)
+    end
+
     def self.flatten_keys(hash)
       hash.each_with_object({}) do |(k, v), h|
         h[flatten_key(k)] = v

--- a/spec/calculator_spec.rb
+++ b/spec/calculator_spec.rb
@@ -147,6 +147,7 @@ describe Dentaku::Calculator do
     it 'stores nested hashes' do
       calculator.store(a: {basket: {of: 'apples'}}, b: 2)
       expect(calculator.evaluate!('a.basket.of')).to eq('apples')
+      expect(calculator.evaluate!('a.basket')).to eq(of: 'apples')
       expect(calculator.evaluate!('b')).to eq(2)
     end
 


### PR DESCRIPTION
In my company we recently got a requirement to also use ruby hashes/json in our Dentaku equations. Until now we've been using the calculator as nested_data_support: true, but that fails if the final value is a hash.

```ruby
Dentaku::Calculator.new.evaluate!('a.b', { a: { b: { c: 1 } } })
# => Dentaku::UnboundVariableError: no value provided for variables: a.b
```

This change would allow using all intermediate values from deep hashes given as valid identifiers.

```ruby
Dentaku::Calculator.new.evaluate!('a.b', { a: { b: { c: 1 } } })
# => {:c=>1}
```

I'm not sure if this should be on by default, I currently left it since all the existing specs pass, but if you think it should be under another option, I'm happy to change that.