### PR TITLE
Make invalid syntax for grouping fail in parse stage

### DIFF
--- a/lib/dentaku/parser.rb
+++ b/lib/dentaku/parser.rb
@@ -51,6 +51,7 @@ module Dentaku
         fail! :too_many_operands, operator: operator, expect: max_size, actual: output.length
       end
 
+      fail! :invalid_statement if output.size < args_size
       args = Array.new(args_size) { output.pop }.reverse
 
       output.push operator.new(*args)

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -71,6 +71,11 @@ describe Dentaku::Parser do
     expect(node.value("x" => 3)).to eq(4)
   end
 
+  it 'evaluates arrays' do
+    node = parse('{1, 2, 3}')
+    expect(node.value).to eq([1, 2, 3])
+  end
+
   context 'invalid expression' do
     it 'raises a parse error for bad math' do
       expect {
@@ -96,6 +101,14 @@ describe Dentaku::Parser do
 
       expect {
         parse("5 + 5, x")
+      }.to raise_error(Dentaku::ParseError)
+
+      expect {
+        parse("{1, 2, }")
+      }.to raise_error(Dentaku::ParseError)
+
+      expect {
+        parse("CONCAT('1', '2', )")
       }.to raise_error(Dentaku::ParseError)
     end
 


### PR DESCRIPTION
Fixes https://github.com/rubysolo/dentaku/issues/205