### PR TITLE
Validate arguments for ruby math

### DIFF
--- a/lib/dentaku/ast/functions/ruby_math.rb
+++ b/lib/dentaku/ast/functions/ruby_math.rb
@@ -1,8 +1,53 @@
 # import all functions from Ruby's Math module
 require_relative '../function'
 
+module Dentaku
+  module AST
+    class RubyMath < Function
+      def self.[](method)
+        klass = Class.new(self)
+        klass.implement(method)
+        klass
+      end
+
+      def self.implement(method)
+        @name = method
+        @implementation = Math.method(method)
+      end
+
+      def self.name
+        @name
+      end
+
+      def self.arity
+        @implementation.arity < 0 ? nil : @implementation.arity
+      end
+
+      def self.min_param_count
+        @implementation.parameters.select { |type, _name| type == :req }.count
+      end
+
+      def self.max_param_count
+        @implementation.parameters.select { |type, _name| type == :rest }.any? ? Float::INFINITY : @implementation.parameters.count
+      end
+
+      def self.call(*args)
+        @implementation.call(*args)
+      end
+
+      def value(context = {})
+        args = @args.flatten.map { |a| Dentaku::AST::Function.numeric(a.value(context)) }
+        self.class.call(*args)
+      end
+
+      def type
+        nil
+      end
+
+    end
+  end
+end
+
 Math.methods(false).each do |method|
-  Dentaku::AST::Function.register(method, :numeric, lambda { |*args|
-    Math.send(method, *args.flatten.map { |arg| Dentaku::AST::Function.numeric(arg) })
-  })
+  Dentaku::AST::Function.register_class(method, Dentaku::AST::RubyMath[method])
 end

--- a/spec/calculator_spec.rb
+++ b/spec/calculator_spec.rb
@@ -605,6 +605,7 @@ describe Dentaku::Calculator do
       it method do
         if Math.method(method).arity == 2
           expect(calculator.evaluate("#{method}(x,y)", x: 1, y: '2')).to eq(Math.send(method, 1, 2))
+          expect { calculator.evaluate!("#{method}(x)", x: 1) }.to raise_error(Dentaku::ParseError)
         else
           expect(calculator.evaluate("#{method}(1)")).to eq(Math.send(method, 1))
         end


### PR DESCRIPTION
Intended to properly validate that correct amount of arguments are passed
and if not to fail in parse stage with Dentaku error rather than in
evaluate stage with unhandled ArgumentError.

