### PR TITLE
Prefer variable value over value from memory in solve()

### DIFF
--- a/spec/calculator_spec.rb
+++ b/spec/calculator_spec.rb
@@ -197,6 +197,15 @@ describe Dentaku::Calculator do
       )).to eq(pear: 1, weekly_apple_budget: 21, weekly_fruit_budget: 25)
     end
 
+    it "prefers variables over existing value in memory" do
+      expect(with_memory.solve!(
+        weekly_fruit_budget: "weekly_apple_budget + pear * 4",
+        weekly_apple_budget: "apples * 7",
+        pear:                "1",
+        apples:              "4"
+      )).to eq(apples: 4, pear: 1, weekly_apple_budget: 28, weekly_fruit_budget: 32)
+    end
+
     it "preserves hash keys" do
       expect(calculator.solve!(
         'meaning_of_life' => 'age + kids',


### PR DESCRIPTION
Ref #223 

* [x] add test to expose an issue
* [ ] trying to figure out how to fix this

Test case:

```ruby
calculator = Dentaku::Calculator.new
calculator.store(apples: 3)
calculator.solve!(
  weekly_fruit_budget: "weekly_apple_budget + pear * 4",
  weekly_apple_budget: "apples * 7",
  pear:                "1",
  apples:              "4"
)
```

The result is incorrect

```ruby
{:apples=>3, :pear=>1, :weekly_apple_budget=>21, :weekly_fruit_budget=>25}
```

This is because it `solve` prefers existing value from memory over the value provided to solve as an argument directly.

The result should be

```ruby
{:apples=>4, :pear=>1, :weekly_apple_budget=>28, :weekly_fruit_budget=>32}
```
