### PR TITLE
Allow aggregate functions to accept empty arrays

### DIFF
--- a/lib/dentaku/ast/functions/mul.rb
+++ b/lib/dentaku/ast/functions/mul.rb
@@ -1,13 +1,12 @@
 require_relative '../function'
 
 Dentaku::AST::Function.register(:mul, :numeric, ->(*args) {
-  flatten_args = args.flatten
-  if flatten_args.empty?
+  if args.empty?
     raise Dentaku::ArgumentError.for(
         :too_few_arguments,
         function_name: 'MUL()', at_least: 1, given: 0
     ), 'MUL() requires at least one argument'
   end
 
-  flatten_args.map { |arg| Dentaku::AST::Function.numeric(arg) }.reduce(1, :*)
+  args.flatten.map { |arg| Dentaku::AST::Function.numeric(arg) }.reduce(1, :*)
 })

--- a/lib/dentaku/ast/functions/sum.rb
+++ b/lib/dentaku/ast/functions/sum.rb
@@ -1,13 +1,12 @@
 require_relative '../function'
 
 Dentaku::AST::Function.register(:sum, :numeric, ->(*args) {
-  flatten_args = args.flatten
-  if flatten_args.empty?
+  if args.empty?
     raise Dentaku::ArgumentError.for(
         :too_few_arguments,
         function_name: 'SUM()', at_least: 1, given: 0
     ), 'SUM() requires at least one argument'
   end
 
-  flatten_args.map { |arg| Dentaku::AST::Function.numeric(arg) }.reduce(0, :+)
+  args.flatten.map { |arg| Dentaku::AST::Function.numeric(arg) }.reduce(0, :+)
 })

--- a/spec/ast/map_spec.rb
+++ b/spec/ast/map_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+require 'dentaku/ast/functions/map'
+require 'dentaku'
+
+describe Dentaku::AST::Map do
+  it 'operates on each value in an array' do
+    result = Dentaku('SUM(MAP(vals, val, val + 1))', vals: [1, 2, 3])
+    expect(result).to eq(9)
+  end
+
+  it 'works with an empty array' do
+    result = Dentaku('MAP(vals, val, val + 1)', vals: [])
+    expect(result).to eq([])
+  end
+end

--- a/spec/ast/max_spec.rb
+++ b/spec/ast/max_spec.rb
@@ -17,4 +17,17 @@ describe 'Dentaku::AST::Function::Max' do
     result = Dentaku('MAX(1, x, 1.8)', x: [1.5, 2.3, 1.7])
     expect(result).to eq(2.3)
   end
+
+  it 'returns the largest value if only an Array is passed' do
+    result = Dentaku('MAX(x)', x: [1.5, 2.3, 1.7])
+    expect(result).to eq(2.3)
+  end
+
+  context 'checking errors' do
+    let(:calculator) { Dentaku::Calculator.new }
+
+    it 'does not raise an error if an empty array is passed' do
+      expect(calculator.evaluate!('MAX(x)', x: [])).to eq(nil)
+    end
+  end
 end

--- a/spec/ast/min_spec.rb
+++ b/spec/ast/min_spec.rb
@@ -17,4 +17,17 @@ describe 'Dentaku::AST::Function::Min' do
     result = Dentaku('MIN(1, x, 1.8)', x: [1.5, 0.3, 1.7])
     expect(result).to eq(0.3)
   end
+
+  it 'returns the smallest value if only an Array is passed' do
+    result = Dentaku('MIN(x)', x: [1.5, 2.3, 1.7])
+    expect(result).to eq(1.5)
+  end
+
+  context 'checking errors' do
+    let(:calculator) { Dentaku::Calculator.new }
+
+    it 'does not raise an error if an empty array is passed' do
+      expect(calculator.evaluate!('MIN(x)', x: [])).to eq(nil)
+    end
+  end
 end

--- a/spec/ast/mul_spec.rb
+++ b/spec/ast/mul_spec.rb
@@ -35,8 +35,9 @@ describe 'Dentaku::AST::Function::Mul' do
       expect { calculator.evaluate!('MUL()') }.to raise_error(Dentaku::ArgumentError)
     end
 
-    it 'raises an error if an empty array is passed' do
-      expect { calculator.evaluate!('MUL(x)', x: []) }.to raise_error(Dentaku::ArgumentError)
+    it 'does not raise an error if an empty array is passed' do
+      result = calculator.evaluate!('MUL(x)', x: [])
+      expect(result).to eq(1)
     end
   end
 end

--- a/spec/ast/sum_spec.rb
+++ b/spec/ast/sum_spec.rb
@@ -35,8 +35,9 @@ describe 'Dentaku::AST::Function::Sum' do
       expect { calculator.evaluate!('SUM()') }.to raise_error(Dentaku::ArgumentError)
     end
 
-    it 'raises an error if an empty array is passed' do
-      expect { calculator.evaluate!('SUM(x)', x: []) }.to raise_error(Dentaku::ArgumentError)
+    it 'does not raise an error if an empty array is passed' do
+      result = calculator.evaluate!('SUM(x)', x: [])
+      expect(result).to eq(0)
     end
   end
 end


### PR DESCRIPTION
This changes the behavior of `SUM` and `MUL` to respectively return 0 and 1 when given an empty array (rather than raising an `ArgumentError`.) Passing _no_ arguments to either is still an error. This seems to be the [usual](https://math.stackexchange.com/questions/1098060/summation-over-an-emptyset) [convention](https://math.stackexchange.com/questions/110546/what-is-the-product-of-the-empty-set) as well as being more user friendly?

`AVG([])` is still an error as there's nothing coherent to fall back to there. `nil` maybe?

Also added specs for `MIN` and `MAX`, which both return `nil` when given an empty array.
