### PR TITLE
Pass memory as context for node dependencies in Calculator#evaluate!

### DIFF
--- a/lib/dentaku/ast/identifier.rb
+++ b/lib/dentaku/ast/identifier.rb
@@ -31,13 +31,13 @@ module Dentaku
       end
 
       def dependencies(context = {})
-        context.key?(identifier) ? dependencies_of(context[identifier]) : [identifier]
+        context.key?(identifier) ? dependencies_of(context[identifier], context) : [identifier]
       end
 
       private
 
-      def dependencies_of(node)
-        node.respond_to?(:dependencies) ? node.dependencies : []
+      def dependencies_of(node, context)
+        node.respond_to?(:dependencies) ? node.dependencies(context) : []
       end
     end
   end

--- a/lib/dentaku/calculator.rb
+++ b/lib/dentaku/calculator.rb
@@ -59,7 +59,7 @@ module Dentaku
       store(data) do
         node = expression
         node = ast(node) unless node.is_a?(AST::Node)
-        unbound = node.dependencies - memory.keys
+        unbound = node.dependencies(memory)
         unless unbound.empty?
           raise UnboundVariableError.new(unbound),
                 "no value provided for variables: #{unbound.uniq.join(', ')}"


### PR DESCRIPTION
Fixes https://github.com/rubysolo/dentaku/issues/239

`BulkExpressionResolver` utilizes the given calculator's `#dependencies` method:

https://github.com/rubysolo/dentaku/blob/d77dd3bc68e68f10d6275aa1889e0379825890f3/lib/dentaku/bulk_expression_solver.rb#L59-L62

Which uses the stored values in `#memory` to find the dependencies:
https://github.com/rubysolo/dentaku/blob/d77dd3bc68e68f10d6275aa1889e0379825890f3/lib/dentaku/calculator.rb#L79-L90

When the expression is later being evaluated, the `#memory` hash is not given to the node's `dependencies` method as a `context`:
https://github.com/rubysolo/dentaku/blob/d77dd3bc68e68f10d6275aa1889e0379825890f3/lib/dentaku/calculator.rb#L59-L66

Thus leading to situations where the dependencies as determined by the `BulkExpressionResolver` for an expression is different than the dependencies given when trying to evaluate it in `Calculator`.  This is problematic for the `IF` node specifically, as it gives different dependencies based on the value of the predicate being evaluated:
https://github.com/rubysolo/dentaku/blob/d77dd3bc68e68f10d6275aa1889e0379825890f3/lib/dentaku/ast/functions/if.rb#L34-L41
