### PR TITLE
Fix function argument count

### DIFF
--- a/lib/dentaku/ast/functions/duration.rb
+++ b/lib/dentaku/ast/functions/duration.rb
@@ -4,11 +4,11 @@ module Dentaku
   module AST
     class Duration < Function
       def self.min_param_count
-        1
+        2
       end
 
       def self.max_param_count
-        1
+        2
       end
 
       class Value

--- a/lib/dentaku/parser.rb
+++ b/lib/dentaku/parser.rb
@@ -43,11 +43,11 @@ module Dentaku
       min_size = operator.arity || operator.min_param_count || count
       max_size = operator.arity || operator.max_param_count || count
 
-      if output.length < min_size
+      if output.length < min_size || args_size < min_size
         fail! :too_few_operands, operator: operator, expect: min_size, actual: output.length
       end
 
-      if output.length > max_size && operations.empty?
+      if output.length > max_size && operations.empty? || args_size > max_size
         fail! :too_many_operands, operator: operator, expect: max_size, actual: output.length
       end
 

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -89,6 +89,16 @@ describe Dentaku::Parser do
       }.to raise_error(Dentaku::ParseError)
     end
 
+    it 'raises a parse error for too many operands' do
+      expect {
+        parse("IF(1, 0, IF(1, 2, 3, 4))")
+      }.to raise_error(Dentaku::ParseError)
+
+      expect {
+        parse("CASE a WHEN 1 THEN true ELSE THEN IF(1, 2, 3, 4) END")
+      }.to raise_error(Dentaku::ParseError)
+    end
+
     it 'raises a parse error for bad grouping structure' do
       expect {
         parse(",")


### PR DESCRIPTION
We were only looking at the amount of available operands,
but we were not checking against the number of operands
we would be actually consuming.

This fix uncovered that Duration has wrong params count

Fixes #243