### PR TITLE
bugfix: variable in deferred arguments should be considered as dependencies

### DIFF
--- a/lib/dentaku/ast/functions/all.rb
+++ b/lib/dentaku/ast/functions/all.rb
@@ -1,21 +1,8 @@
-require_relative '../function'
-require_relative '../../exceptions'
+require_relative './enumerable'
 
 module Dentaku
   module AST
-    class All < Function
-      def self.min_param_count
-        3
-      end
-
-      def self.max_param_count
-        3
-      end
-
-      def deferred_args
-        [1, 2]
-      end
-
+    class All < Enumerable
       def value(context = {})
         collection      = @args[0].value(context)
         item_identifier = @args[1].identifier

--- a/lib/dentaku/ast/functions/any.rb
+++ b/lib/dentaku/ast/functions/any.rb
@@ -1,21 +1,8 @@
-require_relative '../function'
-require_relative '../../exceptions'
+require_relative './enumerable'
 
 module Dentaku
   module AST
-    class Any < Function
-      def self.min_param_count
-        3
-      end
-
-      def self.max_param_count
-        3
-      end
-
-      def deferred_args
-        [1, 2]
-      end
-
+    class Any < Enumerable
       def value(context = {})
         collection      = @args[0].value(context)
         item_identifier = @args[1].identifier

--- a/lib/dentaku/ast/functions/enumerable.rb
+++ b/lib/dentaku/ast/functions/enumerable.rb
@@ -1,0 +1,28 @@
+require_relative '../function'
+require_relative '../../exceptions'
+
+module Dentaku
+  module AST
+    class Enumerable < Function
+      def self.min_param_count
+        3
+      end
+
+      def self.max_param_count
+        3
+      end
+
+      def deferred_args
+        [1, 2]
+      end
+
+      def dependencies(context = {})
+        collection      = @args[0]
+        item_identifier = @args[1].identifier
+        expression      = @args[2]
+
+        collection.dependencies + expression.dependencies - [item_identifier]
+      end
+    end
+  end
+end

--- a/lib/dentaku/ast/functions/filter.rb
+++ b/lib/dentaku/ast/functions/filter.rb
@@ -1,21 +1,8 @@
-require_relative '../function'
-require_relative '../../exceptions'
+require_relative './enumerable'
 
 module Dentaku
   module AST
-    class Filter < Function
-      def self.min_param_count
-        3
-      end
-
-      def self.max_param_count
-        3
-      end
-
-      def deferred_args
-        [1, 2]
-      end
-
+    class Filter < Enumerable
       def value(context = {})
         collection      = @args[0].value(context)
         item_identifier = @args[1].identifier

--- a/lib/dentaku/ast/functions/map.rb
+++ b/lib/dentaku/ast/functions/map.rb
@@ -1,21 +1,8 @@
-require_relative '../function'
-require_relative '../../exceptions'
+require_relative './enumerable'
 
 module Dentaku
   module AST
-    class Map < Function
-      def self.min_param_count
-        3
-      end
-
-      def self.max_param_count
-        3
-      end
-
-      def deferred_args
-        [1, 2]
-      end
-
+    class Map < Enumerable
       def value(context = {})
         collection      = @args[0].value(context)
         item_identifier = @args[1].identifier

--- a/lib/dentaku/ast/functions/xor.rb
+++ b/lib/dentaku/ast/functions/xor.rb
@@ -12,10 +12,6 @@ module Dentaku
         Float::INFINITY
       end
 
-      def deferred_args
-        [1, 2]
-      end
-
       def value(context = {})
         if @args.empty?
           raise Dentaku::ArgumentError.for(

--- a/spec/calculator_spec.rb
+++ b/spec/calculator_spec.rb
@@ -186,6 +186,10 @@ describe Dentaku::Calculator do
     it "finds no dependencies in array literals" do
       expect(calculator.dependencies([1, 2, 3])).to eq([])
     end
+
+    it "finds dependencies in deferred_args" do
+      expect(calculator.dependencies('MAP(vals, val, val + step)')).to eq(['vals', 'step'])
+    end
   end
 
   describe 'solve!' do


### PR DESCRIPTION
for example, currently calculating dependencies of `MAP(vals, val, val + step)` returns `[vals]`, while it should return `[vals, step]`..