### PR TITLE
make comparators raise Dentaku::ArgumentError instead of Dentaku::Error

### DIFF
--- a/lib/dentaku/ast/comparators.rb
+++ b/lib/dentaku/ast/comparators.rb
@@ -38,37 +38,37 @@ module Dentaku
 
     class LessThan < Comparator
       def operator
-        return :<
+        :<
       end
     end
 
     class LessThanOrEqual < Comparator
       def operator
-        return :<=
+        :<=
       end
     end
 
     class GreaterThan < Comparator
       def operator
-        return :>
+        :>
       end
     end
 
     class GreaterThanOrEqual < Comparator
       def operator
-        return :>=
+        :>=
       end
     end
 
     class NotEqual < Comparator
       def operator
-        return :!=
+        :!=
       end
     end
 
     class Equal < Comparator
       def operator
-        return :==
+        :==
       end
     end
   end

--- a/lib/dentaku/ast/comparators.rb
+++ b/lib/dentaku/ast/comparators.rb
@@ -15,72 +15,58 @@ module Dentaku
         raise NotImplementedError
       end
 
+      def value(context = {})
+        l = validate_value(left.value(context))
+        r = validate_value(right.value(context))
+
+        l.public_send(operator, r)
+      rescue ::ArgumentError => e
+        raise Dentaku::ArgumentError.for(:incompatible_type, value: r, for: l.class), e.message
+      end
+
       private
 
-      def value
-        yield
-      rescue ::ArgumentError => argument_error
-        raise Dentaku::ArgumentError, argument_error.message
-      rescue NoMethodError => no_method_error
-        raise Dentaku::Error, no_method_error.message
+      def validate_value(value)
+        unless value.respond_to?(operator)
+          raise Dentaku::ArgumentError.for(:invalid_operator, operation: self.class, operator: operator),
+                "#{ self.class } requires operands that respond to #{operator}"
+        end
+
+        value
       end
     end
 
     class LessThan < Comparator
-      def value(context = {})
-        super() { left.value(context) < right.value(context) }
-      end
-
       def operator
         return :<
       end
     end
 
     class LessThanOrEqual < Comparator
-      def value(context = {})
-        super() { left.value(context) <= right.value(context) }
-      end
-
       def operator
         return :<=
       end
     end
 
     class GreaterThan < Comparator
-      def value(context = {})
-        super() { left.value(context) > right.value(context) }
-      end
-
       def operator
         return :>
       end
     end
 
     class GreaterThanOrEqual < Comparator
-      def value(context = {})
-        super() { left.value(context) >= right.value(context) }
-      end
-
       def operator
         return :>=
       end
     end
 
     class NotEqual < Comparator
-      def value(context = {})
-        super() { left.value(context) != right.value(context) }
-      end
-
       def operator
         return :!=
       end
     end
 
     class Equal < Comparator
-      def value(context = {})
-        super() { left.value(context) == right.value(context) }
-      end
-
       def operator
         return :==
       end

--- a/spec/ast/comparator_spec.rb
+++ b/spec/ast/comparator_spec.rb
@@ -26,15 +26,16 @@ describe Dentaku::AST::Comparator do
     expect { less_than_or_equal(one, nilly).value(ctx) }.to raise_error Dentaku::ArgumentError
     expect { greater_than(one, nilly).value(ctx) }.to raise_error Dentaku::ArgumentError
     expect { greater_than_or_equal(one, nilly).value(ctx) }.to raise_error Dentaku::ArgumentError
+    expect { greater_than_or_equal(one, x).value(ctx) }.to raise_error Dentaku::ArgumentError
     expect { not_equal(one, nilly).value(ctx) }.to_not raise_error
     expect { equal(one, nilly).value(ctx) }.to_not raise_error
   end
 
-  it 'raises a dentaku error when nil is passed in as first argument' do
-    expect { less_than(nilly, one).value(ctx) }.to raise_error Dentaku::Error
-    expect { less_than_or_equal(nilly, one).value(ctx) }.to raise_error Dentaku::Error
-    expect { greater_than(nilly, one).value(ctx) }.to raise_error Dentaku::Error
-    expect { greater_than_or_equal(nilly, one).value(ctx) }.to raise_error Dentaku::Error
+  it 'raises a dentaku argument error when nil is passed in as first argument' do
+    expect { less_than(nilly, one).value(ctx) }.to raise_error Dentaku::ArgumentError
+    expect { less_than_or_equal(nilly, one).value(ctx) }.to raise_error Dentaku::ArgumentError
+    expect { greater_than(nilly, one).value(ctx) }.to raise_error Dentaku::ArgumentError
+    expect { greater_than_or_equal(nilly, one).value(ctx) }.to raise_error Dentaku::ArgumentError
     expect { not_equal(nilly, one).value(ctx) }.to_not raise_error
     expect { equal(nilly, one).value(ctx) }.to_not raise_error
   end
@@ -48,10 +49,6 @@ describe Dentaku::AST::Comparator do
     expect(equal(x, y).operator).to eq(:==)
     expect { Dentaku::AST::Comparator.new(one, two).operator }
       .to raise_error(NotImplementedError)
-  end
-
-  it 'relies on inheriting classes to expose value method' do
-    expect { described_class.new(one, two).value(ctx) }.to raise_error NoMethodError
   end
 
   private

--- a/spec/calculator_spec.rb
+++ b/spec/calculator_spec.rb
@@ -262,8 +262,13 @@ describe Dentaku::Calculator do
 
   describe 'solve' do
     it "returns :undefined when variables are unbound" do
-      expressions = {more_apples: "apples + 1"}
-      expect(calculator.solve(expressions)).to eq(more_apples: :undefined)
+      expressions = {more_apples: "apples + 1", compare_apples: "apples > 1"}
+      expect(calculator.solve(expressions)).to eq(more_apples: :undefined, compare_apples: :undefined)
+    end
+
+    it "returns :undefined when variables are nil" do
+      expressions = {more_apples: "apples + 1", compare_apples: "apples > 1"}
+      expect(calculator.store(apples: nil).solve(expressions)).to eq(more_apples: :undefined, compare_apples: :undefined)
     end
 
     it "allows passing in a custom value to an error handler" do


### PR DESCRIPTION
- make comparators raise `Dentaku::ArgumentError` instead of `Dentaku::Error` when operands don't respond to operator.
- refactor comparators code a bit to make it more consistent with `Arithmetic` class
- update specs

Fixes: https://github.com/rubysolo/dentaku/issues/252