### PR TITLE
Marshal.dump support for ruby math functions

### DIFF
--- a/lib/dentaku/ast/functions/ruby_math.rb
+++ b/lib/dentaku/ast/functions/ruby_math.rb
@@ -5,9 +5,10 @@ module Dentaku
   module AST
     class RubyMath < Function
       def self.[](method)
-        klass = Class.new(self)
+        klass_name = method.to_s.capitalize
+        klass = const_set(klass_name , Class.new(self))
         klass.implement(method)
-        klass
+        const_get(klass_name)
       end
 
       def self.implement(method)

--- a/spec/calculator_spec.rb
+++ b/spec/calculator_spec.rb
@@ -715,6 +715,12 @@ describe Dentaku::Calculator do
         end
       end
     end
+
+    it 'are defined with a properly named class that represents it to support AST marshaling' do
+      expect {
+        Marshal.dump(calculator.ast('SQRT(20)'))
+      }.not_to raise_error
+    end
   end
 
   describe 'disable_cache' do


### PR DESCRIPTION
Fixes #259 

Assigning each generated Ruby `Math` method class to a constant inside `Dentaku::AST::RubyMath` and returning the constant to avoid anonymous classes.