### PR TITLE
Handle E or e at numeric token scanner

### DIFF
--- a/lib/dentaku/token_scanner.rb
+++ b/lib/dentaku/token_scanner.rb
@@ -91,7 +91,7 @@ module Dentaku
 
       def numeric
         new(:numeric, '((?:\d+(\.\d+)?|\.\d+)(?:(e|E)(\+|-)?\d+)?)\b', lambda { |raw|
-          raw =~ /\./ ? BigDecimal(raw) : raw.to_i
+          raw =~ /(\.|e|E)/ ? BigDecimal(raw) : raw.to_i
         })
       end
 

--- a/spec/tokenizer_spec.rb
+++ b/spec/tokenizer_spec.rb
@@ -25,6 +25,9 @@ describe Dentaku::Tokenizer do
       expect(tokens.map(&:category)).to eq([:numeric])
       expect(tokens.map(&:value)).to eq([6.02e23])
     end
+
+    token = tokenizer.tokenize('6E23')
+    expect(token.map(&:value)).to eq([0.6e24])
   end
 
   it 'tokenizes addition' do


### PR DESCRIPTION
Fixes #261.

## Before
```
calculator.evaluate("6E23")
# => 6
```
it comes from
```
"6E23".to_i
#=> 6
```

## After
```
calculator.evaluate("6E23")
# => 0.6e24
```
it comes from
```
BigDecimal(6E23)
#=> 0.6e24
```