### PR TITLE
Update nested case statement subparsing to respect case-sensitivity

### DIFF
--- a/lib/dentaku/parser.rb
+++ b/lib/dentaku/parser.rb
@@ -144,7 +144,8 @@ module Dentaku
                 inner_case_inputs,
                 operations: [AST::Case],
                 arities: [0],
-                function_registry: @function_registry
+                function_registry: @function_registry,
+                case_sensitive: case_sensitive
               )
               subparser.parse
               output.concat(subparser.output)

--- a/spec/calculator_spec.rb
+++ b/spec/calculator_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 require 'dentaku'
 describe Dentaku::Calculator do
   let(:calculator)   { described_class.new }
+  let(:with_case_sensitivity) { described_class.new(case_sensitive: true)}
   let(:with_memory)  { described_class.new.store(apples: 3) }
   let(:with_aliases) { described_class.new(aliases: { round: ['rrround'] }) }
   let(:without_nested_data) { described_class.new(nested_data_support: false) }
@@ -686,6 +687,31 @@ describe Dentaku::Calculator do
         formula,
         type: 'organic',
         quantity: 10,
+        fruit: 'banana')
+      expect(value).to eq(5)
+    end
+
+    it 'handles nested case statements with case-sensitivity' do
+      formula = <<-FORMULA
+      CASE fruit
+      WHEN 'apple'
+        THEN 1 * quantity
+      WHEN 'banana'
+        THEN
+        CASE QUANTITY
+        WHEN 1 THEN 2
+        WHEN 10 THEN
+          CASE type
+          WHEN 'organic' THEN 5
+          END
+        END
+      END
+      FORMULA
+      value = with_case_sensitivity.evaluate(
+        formula,
+        type: 'organic',
+        quantity: 1,
+        QUANTITY: 10,
         fruit: 'banana')
       expect(value).to eq(5)
     end

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -71,6 +71,12 @@ describe Dentaku::Parser do
     expect(node.value("x" => 3)).to eq(4)
   end
 
+  it 'evaluates a nested case statement with case-sensitivity' do
+    node = parse('CASE x WHEN 1 THEN CASE Y WHEN "A" THEN 2 WHEN "B" THEN 3 END END', { case_sensitive: true }, { case_sensitive: true })
+    puts node.inspect
+    expect(node.value("x" => 1, "y" => "A", "Y" => "B")).to eq(3)
+  end
+
   it 'evaluates arrays' do
     node = parse('{1, 2, 3}')
     expect(node.value).to eq([1, 2, 3])
@@ -154,8 +160,8 @@ describe Dentaku::Parser do
 
   private
 
-  def parse(expr)
-    tokens = Dentaku::Tokenizer.new.tokenize(expr)
-    described_class.new(tokens).parse
+  def parse(expr, parser_options={}, tokenizer_options={})
+    tokens = Dentaku::Tokenizer.new.tokenize(expr, tokenizer_options)
+    described_class.new(tokens, parser_options).parse
   end
 end


### PR DESCRIPTION
This fixes an issue where nested case statements wouldn't respect case-sensitivity settings of the parser