### PR TITLE
Add automatic conversion to numeric in comparators

### DIFF
--- a/lib/dentaku/ast/comparators.rb
+++ b/lib/dentaku/ast/comparators.rb
@@ -16,8 +16,8 @@ module Dentaku
       end
 
       def value(context = {})
-        l = validate_value(left.value(context))
-        r = validate_value(right.value(context))
+        l = validate_value(cast(left.value(context)))
+        r = validate_value(cast(right.value(context)))
 
         l.public_send(operator, r)
       rescue ::ArgumentError => e
@@ -25,6 +25,16 @@ module Dentaku
       end
 
       private
+
+      def cast(val)
+        return val unless val.is_a?(::String)
+        return val if val.empty?
+        return val unless val.match?(/\A-?\d*(\.\d+)?\z/)
+
+        v = BigDecimal(val, Float::DIG + 1)
+        v = v.to_i if v.frac.zero?
+        v
+      end
 
       def validate_value(value)
         unless value.respond_to?(operator)

--- a/spec/ast/comparator_spec.rb
+++ b/spec/ast/comparator_spec.rb
@@ -5,7 +5,9 @@ require 'dentaku/token'
 
 describe Dentaku::AST::Comparator do
   let(:one) { Dentaku::AST::Numeric.new Dentaku::Token.new(:numeric, 1) }
+  let(:one_str) { Dentaku::AST::String.new Dentaku::Token.new(:string, '1') }
   let(:two) { Dentaku::AST::Numeric.new Dentaku::Token.new(:numeric, 2) }
+  let(:two_str) { Dentaku::AST::String.new Dentaku::Token.new(:string, '2') }
   let(:x) { Dentaku::AST::Identifier.new Dentaku::Token.new(:identifier, 'x') }
   let(:y) { Dentaku::AST::Identifier.new Dentaku::Token.new(:identifier, 'y') }
   let(:nilly) do
@@ -19,6 +21,12 @@ describe Dentaku::AST::Comparator do
     expect(greater_than(two, one).value(ctx)).to be_truthy
     expect(not_equal(x, y).value(ctx)).to be_truthy
     expect(equal(x, y).value(ctx)).to be_falsey
+  end
+
+  it 'performs conversion from string to numeric operands' do
+    expect(less_than(one, two_str).value(ctx)).to be_truthy
+    expect(less_than(one_str, two_str).value(ctx)).to be_truthy
+    expect(less_than(one_str, two).value(ctx)).to be_truthy
   end
 
   it 'raises a dentaku argument error when incorrect arguments are passed in' do

--- a/spec/ast/or_spec.rb
+++ b/spec/ast/or_spec.rb
@@ -6,7 +6,7 @@ describe 'Dentaku::AST::Or' do
   let(:calculator) { Dentaku::Calculator.new }
 
   it 'returns false if all of the arguments are false' do
-    result = Dentaku('OR(1 = "1", 0 = 1)')
+    result = Dentaku('OR(1 = "2", 0 = 1)')
     expect(result).to eq(false)
   end
 


### PR DESCRIPTION
I hope I'm not stepping on anybody's shoes here..

I found existing issue #255 which is also something that we would find very useful.. given how long the issue has been opened, I took the liberty to try to open a PR to fix it..

with this PR, comparison functions would now automatically convert numeric like string into BigDecimal, so that comparison between number and strings would work as expected..