### PR TITLE
handle when `val` is not string in `#numeric`

### DIFF
--- a/lib/dentaku/ast/arithmetic.rb
+++ b/lib/dentaku/ast/arithmetic.rb
@@ -48,7 +48,7 @@ module Dentaku
       end
 
       def numeric(val)
-        case val
+        case val.to_s
         when /\.\d+/ then decimal(val)
         when /\d+/ then val.to_i
         else val
@@ -56,7 +56,7 @@ module Dentaku
       end
 
       def decimal(val)
-        BigDecimal(val, Float::DIG + 1)
+        BigDecimal(val.to_s, Float::DIG + 1)
       end
 
       def valid_node?(node)


### PR DESCRIPTION
Thanks to https://github.com/rubysolo/dentaku/commit/2246cb99143fa9aedc896b3525a6f5b2050726a0, I get BigDecimal result from the below calculation:
```
Dentaku::Calculator.new.evaluate( 'orange + 2',  orange: "23.4").class
#=> BigDecimal

```

However, when non-string value is passed, this returns Float value

```
Dentaku::Calculator.new.evaluate( 'orange + 2',  orange: 23.4).class
#=> Float
```

tried to fix the second calculation also to return the BigDecimal result.