### PR TITLE
Bitwise shift left and right operators (`<<` & `>>`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ application, AST caching will consume more memory with each new formula.
 BUILT-IN OPERATORS AND FUNCTIONS
 ---------------------------------
 
-Math: `+`, `-`, `*`, `/`, `%`, `^`, `|`, `&`
+Math: `+`, `-`, `*`, `/`, `%`, `^`, `|`, `&`, `<<`, `>>`
 
 Also, all functions from Ruby's Math module, including `SIN`, `COS`, `TAN`, etc.
 

--- a/lib/dentaku/ast/bitwise.rb
+++ b/lib/dentaku/ast/bitwise.rb
@@ -21,5 +21,25 @@ module Dentaku
         :&
       end
     end
+
+    class BitwiseShiftLeft < Operation
+      def value(context = {})
+        left.value(context) << right.value(context)
+      end
+
+      def operator
+        :<<
+      end
+    end
+
+    class BitwiseShiftRight < Operation
+      def value(context = {})
+        left.value(context) >> right.value(context)
+      end
+
+      def operator
+        :>>
+      end
+    end
   end
 end

--- a/lib/dentaku/parser.rb
+++ b/lib/dentaku/parser.rb
@@ -10,8 +10,11 @@ module Dentaku
       pow:      AST::Exponentiation,
       negate:   AST::Negation,
       mod:      AST::Modulo,
+
       bitor:    AST::BitwiseOr,
       bitand:   AST::BitwiseAnd,
+      bitshiftleft:  AST::BitwiseShiftLeft,
+      bitshiftright: AST::BitwiseShiftRight,
 
       lt:       AST::LessThan,
       gt:       AST::GreaterThan,

--- a/lib/dentaku/token_scanner.rb
+++ b/lib/dentaku/token_scanner.rb
@@ -120,9 +120,9 @@ module Dentaku
 
       def operator
         names = {
-          pow: '^', add: '+', subtract: '-', multiply: '*', divide: '/', mod: '%', bitor: '|', bitand: '&'
+          pow: '^', add: '+', subtract: '-', multiply: '*', divide: '/', mod: '%', bitor: '|', bitand: '&', bitshiftleft: '<<', bitshiftright: '>>'
         }.invert
-        new(:operator, '\^|\+|-|\*|\/|%|\||&', lambda { |raw| names[raw] })
+        new(:operator, '\^|\+|-|\*|\/|%|\||&|<<|>>', lambda { |raw| names[raw] })
       end
 
       def grouping

--- a/spec/calculator_spec.rb
+++ b/spec/calculator_spec.rb
@@ -40,6 +40,8 @@ describe Dentaku::Calculator do
     expect(calculator.evaluate("2 | 3 * 9")).to eq (27)
     expect(calculator.evaluate("2 & 3 * 9")).to eq (2)
     expect(calculator.evaluate("5%")).to eq (0.05)
+    expect(calculator.evaluate('1 << 3')).to eq (8)
+    expect(calculator.evaluate('0xFF >> 14')).to eq (3)
   end
 
   describe 'evaluate' do

--- a/spec/tokenizer_spec.rb
+++ b/spec/tokenizer_spec.rb
@@ -89,6 +89,18 @@ describe Dentaku::Tokenizer do
     expect(tokens.map(&:value)).to eq([2, :bitand, 3])
   end
 
+  it 'tokenizes bitwise SHIFT LEFT' do
+    tokens = tokenizer.tokenize('2 << 3')
+    expect(tokens.map(&:category)).to eq([:numeric, :operator, :numeric])
+    expect(tokens.map(&:value)).to eq([2, :bitshiftleft, 3])
+  end
+
+  it 'tokenizes bitwise SHIFT RIGHT' do
+    tokens = tokenizer.tokenize('2 >> 3')
+    expect(tokens.map(&:category)).to eq([:numeric, :operator, :numeric])
+    expect(tokens.map(&:value)).to eq([2, :bitshiftright, 3])
+  end
+
   it 'ignores whitespace' do
     tokens = tokenizer.tokenize('1     / 1     ')
     expect(tokens.map(&:category)).to eq([:numeric, :operator, :numeric])

--- a/spec/visitor_spec.rb
+++ b/spec/visitor_spec.rb
@@ -111,7 +111,7 @@ describe TestVisitor do
     visit_nodes('1 < 2 and 3 <= 4 or 5 > 6 AND 7 >= 8 OR 9 != 10 and true')
     visit_nodes('IF(a[0] = NULL, "five", \'seven\')')
     visit_nodes('case (a % 5) when 0 then a else b end')
-    visit_nodes('0xCAFE & 0xDECAF | 0xBEEF')
+    visit_nodes('0xCAFE & (0xDECAF << 3) | (0xBEEF >> 5)')
     visit_nodes('2017-12-24 23:59:59')
     visit_nodes('ALL({1, 2, 3}, "val", val % 2 == 0)')
     visit_nodes('ANY(vals, val, val > 1)')


### PR DESCRIPTION
Hey, this is a naive implementation of the missing (but useful) bitwise shift left `<<` and right `>>` operators. I've just copied what was done for the `|` and `&` operators, and added some basic tests.