### PR TITLE
Validate enum arguments on parse stage rather than dependency stage

### DIFF
--- a/lib/dentaku/ast/functions/enum.rb
+++ b/lib/dentaku/ast/functions/enum.rb
@@ -12,9 +12,12 @@ module Dentaku
         3
       end
 
-      def dependencies(context = {})
+      def initialize(*args)
+        super
         validate_identifier(@args[1])
+      end
 
+      def dependencies(context = {})
         collection      = @args[0]
         item_identifier = @args[1].identifier
         expression      = @args[2]
@@ -28,9 +31,7 @@ module Dentaku
       end
 
       def validate_identifier(arg, message = "#{name}() requires second argument to be an identifier")
-        unless arg.is_a?(Identifier)
-          raise ArgumentError.for(:incompatible_type, value: arg, for: Identifier), message
-        end
+        raise ParseError.for(:node_invalid), message unless arg.is_a?(Identifier)
       end
     end
   end

--- a/spec/ast/all_spec.rb
+++ b/spec/ast/all_spec.rb
@@ -19,7 +19,7 @@ describe Dentaku::AST::All do
 
   it 'raises argument error if a string is passed as identifier' do
     expect { calculator.evaluate!('ALL({1, 2, 3}, "val", val % 2 == 0)') }.to raise_error(
-      Dentaku::ArgumentError, 'ALL() requires second argument to be an identifier'
+      Dentaku::ParseError, 'ALL() requires second argument to be an identifier'
     )
   end
 end

--- a/spec/ast/any_spec.rb
+++ b/spec/ast/any_spec.rb
@@ -18,6 +18,6 @@ describe Dentaku::AST::Any do
   end
 
   it 'raises argument error if a string is passed as identifier' do
-    expect { calculator.evaluate!('ANY({1, 2, 3}, "val", val % 2 == 0)') }.to raise_error(Dentaku::ArgumentError)
+    expect { calculator.evaluate!('ANY({1, 2, 3}, "val", val % 2 == 0)') }.to raise_error(Dentaku::ParseError)
   end
 end

--- a/spec/ast/filter_spec.rb
+++ b/spec/ast/filter_spec.rb
@@ -19,7 +19,7 @@ describe Dentaku::AST::Filter do
 
   it 'raises argument error if a string is passed as identifier' do
     expect { calculator.evaluate!('FILTER({1, 2, 3}, "val", val % 2 == 0)') }.to raise_error(
-      Dentaku::ArgumentError, 'FILTER() requires second argument to be an identifier'
+      Dentaku::ParseError, 'FILTER() requires second argument to be an identifier'
     )
   end
 end

--- a/spec/ast/map_spec.rb
+++ b/spec/ast/map_spec.rb
@@ -21,7 +21,7 @@ describe Dentaku::AST::Map do
 
   it 'raises argument error if a string is passed as identifier' do
     expect { calculator.evaluate!('MAP({1, 2, 3}, "val", val + 1)') }.to raise_error(
-      Dentaku::ArgumentError,  'MAP() requires second argument to be an identifier'
+      Dentaku::ParseError,  'MAP() requires second argument to be an identifier'
     )
   end
 end

--- a/spec/ast/pluck_spec.rb
+++ b/spec/ast/pluck_spec.rb
@@ -21,7 +21,7 @@ describe Dentaku::AST::Pluck do
     expect do Dentaku.evaluate!('PLUCK(users, "age")', users: [
       {name: "Bob",  age: 44},
       {name: "Jane", age: 27}
-    ]) end.to raise_error(Dentaku::ArgumentError, 'PLUCK() requires second argument to be an identifier')
+    ]) end.to raise_error(Dentaku::ParseError, 'PLUCK() requires second argument to be an identifier')
   end
 
   it 'raises argument error if a non array of hashes is passed as collection' do

--- a/spec/visitor_spec.rb
+++ b/spec/visitor_spec.rb
@@ -114,7 +114,7 @@ describe TestVisitor do
     visit_nodes('case (a % 5) when 0 then a else b end')
     visit_nodes('0xCAFE & (0xDECAF << 3) | (0xBEEF >> 5)')
     visit_nodes('2017-12-24 23:59:59')
-    visit_nodes('ALL({1, 2, 3}, "val", val % 2 == 0)')
+    visit_nodes('ALL({1, 2, 3}, val, val % 2 == 0)')
     visit_nodes('ANY(vals, val, val > 1)')
     visit_nodes('COUNT({1, 2, 3})')
     visit_nodes('PLUCK(users, age)')


### PR DESCRIPTION
https://github.com/rubysolo/dentaku/commit/0ead564a53126bd840d4441fe7775fb5f311802c introduced a change that made enum functions able to fail with a `Dentaku::ArgumentError` upon calling `dependencies`. This previously happened in the evaluation stage.

This was unexpected to me since until then errors were only raised on either the parse stage or the evaluation stage, but not during resolving dependencies. There is also no safe alternative to `dependencies` unlike `evaluate` is for `evaluate!`

This change will make the argument validation happen in the parse stage. Unlike other type validations (numeric for math functions) this can happen in the parse stage since no non-identifier can evaluate to become an identifier later.

It even found an error in an existing test case.

