### PR TITLE
Add lambda function to process external function arguments

### DIFF
--- a/lib/dentaku/ast/function_registry.rb
+++ b/lib/dentaku/ast/function_registry.rb
@@ -8,7 +8,7 @@ module Dentaku
         nil
       end
 
-      def register(name, type, implementation)
+      def register(name, type, implementation, callback = nil)
         function = Class.new(Function) do
           def self.name=(name)
             @name = name
@@ -32,6 +32,14 @@ module Dentaku
 
           def self.type
             @type
+          end
+
+          def self.callback=(callback)
+            @callback = callback
+          end
+
+          def self.callback
+            @callback
           end
 
           def self.arity
@@ -61,6 +69,7 @@ module Dentaku
         function.name = name
         function.type = type
         function.implementation = implementation
+        function.callback = callback
 
         self[function_name(name)] = function
       end

--- a/lib/dentaku/calculator.rb
+++ b/lib/dentaku/calculator.rb
@@ -24,17 +24,17 @@ module Dentaku
       @function_registry = Dentaku::AST::FunctionRegistry.new
     end
 
-    def self.add_function(name, type, body)
-      Dentaku::AST::FunctionRegistry.default.register(name, type, body)
+    def self.add_function(name, type, body, callback = nil)
+      Dentaku::AST::FunctionRegistry.default.register(name, type, body, callback)
     end
 
-    def add_function(name, type, body)
-      @function_registry.register(name, type, body)
+    def add_function(name, type, body, callback = nil)
+      @function_registry.register(name, type, body, callback)
       self
     end
 
     def add_functions(fns)
-      fns.each { |(name, type, body)| add_function(name, type, body) }
+      fns.each { |(name, type, body, callback)| add_function(name, type, body, callback) }
       self
     end
 

--- a/lib/dentaku/parser.rb
+++ b/lib/dentaku/parser.rb
@@ -61,6 +61,10 @@ module Dentaku
       args = Array.new(args_size) { output.pop }.reverse
 
       output.push operator.new(*args)
+
+      if operator.respond_to?(:callback) && !operator.callback.nil?
+        operator.callback.call(args)
+      end
     rescue ::ArgumentError => e
       raise Dentaku::ArgumentError, e.message
     rescue NodeError => e

--- a/spec/external_function_lambda_spec.rb
+++ b/spec/external_function_lambda_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+require 'dentaku'
+require 'dentaku/calculator'
+
+describe Dentaku::Calculator do
+  describe 'functions' do
+    describe 'external functions' do
+
+      let(:with_external_funcs) do
+        c = described_class.new
+
+        @counts = Hash.new(0)
+
+        @initial_time = "2023-02-03"
+        @last_time = @initial_time
+
+        c.add_function(
+            :reverse,
+            :stringl,
+            ->(a) { a.reverse },
+            lambda do |args|
+              args.each do |arg|
+                @counts[arg.value] += 1 if arg.type == :string
+              end
+            end
+        )
+
+        fns = [
+            [:biggest_callback,  :numeric, ->(*args) { args.max }, ->(args) { args.each { |arg| raise Dentaku::ArgumentError unless arg.type == :numeric } }],
+            [:pythagoras, :numeric, ->(l1, l2) { Math.sqrt(l1**2 + l2**2) }, ->(e) { @last_time = Time.now.to_s }],
+            [:callback_lambda, :string, ->() { " " }, ->() { "lambda executed" }],
+            [:no_lambda_function, :numeric, ->(a) { a**a }],
+        ]
+
+        c.add_functions(fns)
+      end
+
+      it 'includes BIGGEST_CALLBACK' do
+        expect(with_external_funcs.evaluate('BIGGEST_CALLBACK(1, 2, 5, 4)')).to eq(5)
+        expect { with_external_funcs.dependencies('BIGGEST_CALLBACK(1, 3, 6, "hi", 10)') }.to raise_error(Dentaku::ArgumentError)
+      end
+
+      it 'includes REVERSE' do
+        expect(with_external_funcs.evaluate('REVERSE(\'Dentaku\')')).to eq('ukatneD')
+        expect { with_external_funcs.evaluate('REVERSE(22)') }.to raise_error(NoMethodError)
+        expect(@counts["Dentaku"]).to eq(1)
+      end
+
+      it 'includes PYTHAGORAS' do
+        expect(with_external_funcs.evaluate('PYTHAGORAS(8, 7)')).to eq(10.63014581273465)
+        expect(with_external_funcs.evaluate('PYTHAGORAS(3, 4)')).to eq(5)
+        expect(@last_time).not_to eq(@initial_time)
+      end
+
+      it 'call CALLBACK method of function' do
+        expect(Dentaku::AST::Function::Callback_lambda.callback.call()).to eq("lambda executed")
+      end
+
+      it 'call CALLBACK in no external function' do
+        expect { Dentaku::AST::If.callback.call }.to raise_error(NoMethodError)
+      end
+
+      it 'set CALLBACK to nil in external function with no callback' do
+        expect(Dentaku::AST::Function::No_lambda_function.callback).to eq(nil)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds the possibility to process external functions arguments through a lambda function. Lambda is added when the function is added(with `add_function` method), is an optional parameter(nil by default) and its called when all arguments of an operator are parsed.
Adding this lambda gives us the chance of for instance:
- validate arguments of a function(type, content)
- keep usage statistics(frequency and last time used, most used arguments).
