### PR TITLE
return avg function value as bigdecimal for improving accuracy

### DIFF
--- a/lib/dentaku/ast/functions/avg.rb
+++ b/lib/dentaku/ast/functions/avg.rb
@@ -9,5 +9,5 @@ Dentaku::AST::Function.register(:avg, :numeric, ->(*args) {
     ), 'AVG() requires at least one argument'
   end
 
-  flatten_args.map { |arg| Dentaku::AST::Function.numeric(arg) }.reduce(0, :+) / flatten_args.length
+  flatten_args.map { |arg| Dentaku::AST::Function.numeric(arg) }.reduce(0, :+) / BigDecimal(flatten_args.length)
 })

--- a/spec/ast/avg_spec.rb
+++ b/spec/ast/avg_spec.rb
@@ -3,6 +3,11 @@ require 'dentaku/ast/functions/avg'
 require 'dentaku'
 
 describe 'Dentaku::AST::Function::Avg' do
+  it 'returns the average of an array of Numeric values as BigDecimal' do
+    result = Dentaku('AVG(1, 2)')
+    expect(result).to eq(1.5)
+  end
+
   it 'returns the average of an array of Numeric values' do
     result = Dentaku('AVG(1, x, 1.8)', x: 2.3)
     expect(result).to eq(1.7)


### PR DESCRIPTION
Greetings 🙇‍♀️ 
I am having trouble getting an accurate result when using the AVG function with decimal values。
For example, when I run AVG(2, 3), 
- I expect the result to be 2.5, 
- but the actual result is 2.

I have made modifications to the code to ensure that it always returns a BigDecimal value.

before
```
c = Dentaku::Calculator.new
c.evaluate!("AVG(2, 3)")
#=> 2

c.evaluate!("AVG(2, 3.1)")
#=> 0.255e1
```

after
```
c = Dentaku::Calculator.new
c.evaluate!("AVG(2, 3)")
#=> 0.25e1

c.evaluate!("AVG(2, 3.1)")
#=> 0.255e1
```