### PR TITLE
add support for concatenating an array

### DIFF
--- a/lib/dentaku/ast/functions/string_functions.rb
+++ b/lib/dentaku/ast/functions/string_functions.rb
@@ -172,7 +172,17 @@ module Dentaku
         end
 
         def value(context = {})
-          @args.map { |arg| arg.value(context).to_s }.join
+          collection(context).map { |member| member.to_s }.join
+        end
+
+        private
+
+        def collection(context)
+          collection = @args.map { |arg| arg.value(context) }
+
+          return collection[0] if collection.length == 1 && collection[0].respond_to?(:join)
+
+          collection
         end
       end
 

--- a/spec/ast/string_functions_spec.rb
+++ b/spec/ast/string_functions_spec.rb
@@ -198,6 +198,11 @@ describe Dentaku::AST::StringFunctions::Concat do
     expect(subject.value).to eq ''
   end
 
+  it 'concatenates an array' do
+    subject = described_class.new(literal(['ABC', 'DEF']))
+    expect(subject.value).to eq 'ABCDEF'
+  end
+
   it 'has the proper type' do
     expect(subject.type).to eq(:string)
   end


### PR DESCRIPTION
This is very useful for map reducing an array of complex data, e.g.

```
CONCAT(
  MAP(
    arr,
    item,
    CONCAT(item.name, ", ")
  )
)
```

This will still introduce extra `, ` at the end, but then it can still be cleaned using `LEFT(str, LEN(str) - 2)`..

Though, ideally, `CONCAT` should support passing custom `separator` to be pass into `.join(separator)`.. but, I'm not sure how to do that while still supporting the variable length arguments that it currently support..

Supporting it only in the case when the users are passing an array as a first argument, e.g. `CONCAT(arr, ', ')` can be considered, but it feels like an inconsistency..

wdyt?