### PR TITLE
Make sure arithmetic performed by custom class is not raising error

### DIFF
--- a/lib/dentaku/ast/arithmetic.rb
+++ b/lib/dentaku/ast/arithmetic.rb
@@ -62,6 +62,8 @@ module Dentaku
 
       def decimal(val)
         BigDecimal(val.to_s, Float::DIG + 1)
+      rescue # return as is, in case value can't be coerced to big decimal
+        val
       end
 
       def datetime?(val)

--- a/spec/ast/arithmetic_spec.rb
+++ b/spec/ast/arithmetic_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 require 'dentaku/ast/arithmetic'
-
-require 'dentaku/token'
+require 'dentaku'
 
 describe Dentaku::AST::Arithmetic do
   let(:one)  { Dentaku::AST::Numeric.new(Dentaku::Token.new(:numeric, 1)) }
@@ -64,10 +63,52 @@ describe Dentaku::AST::Arithmetic do
 
   it 'performs arithmetic on arrays' do
     expect(add(x, y, 'x' => [1], 'y' => [2])).to eq([1, 2])
+    expect(sub(x, y, 'x' => [1], 'y' => [2])).to eq([1])
   end
 
   it 'performs date arithmetic' do
     expect(add(date, one)).to eq(DateTime.new(2020, 4, 17))
+    expect(sub(date, one)).to eq(DateTime.new(2020, 4, 15))
+  end
+
+  it 'performs arithmetic on object which implements arithmetic' do
+    Operand = Struct.new(:value) do
+      extend Forwardable
+
+      def_delegators :value, :zero?
+
+      def coerce(other)
+        case other
+        when Numeric
+          [other, value]
+        else
+          super
+        end
+      end
+
+      [:+, :-, :/, :*].each do |operand|
+        define_method(operand) do |other|
+          case other
+          when Operand
+            value.public_send(operand, other.value)
+          when Numeric
+            value.public_send(operand, other)
+          end
+        end
+      end
+    end
+
+    op_one = Operand.new(1)
+    op_two = Operand.new(2)
+
+    [op_two, two].each do |left|
+      [op_one, one].each do |right|
+        expect(add(x, y, 'x' => left, 'y' => right)).to eq(3)
+        expect(sub(x, y, 'x' => left, 'y' => right)).to eq(1)
+        expect(mul(x, y, 'x' => left, 'y' => right)).to eq(2)
+        expect(div(x, y, 'x' => left, 'y' => right)).to eq(2)
+      end
+    end
   end
 
   it 'raises ArgumentError if given individually valid but incompatible arguments' do

--- a/spec/ast/division_spec.rb
+++ b/spec/ast/division_spec.rb
@@ -32,4 +32,29 @@ describe Dentaku::AST::Division do
       described_class.new(group, five)
     }.not_to raise_error
   end
+
+  it 'allows operands that respond to division' do
+    # Sample struct that has a custom definition for division
+    Operand = Struct.new(:value) do
+      def /(other)
+        case other
+        when Operand
+          value + other.value
+        when Numeric
+          value + other
+        end
+      end
+    end
+
+    operand_five = Dentaku::AST::Numeric.new Dentaku::Token.new(:numeric, Operand.new(5))
+    operand_six = Dentaku::AST::Numeric.new Dentaku::Token.new(:numeric, Operand.new(6))
+
+    expect {
+      described_class.new(operand_five, operand_six)
+    }.not_to raise_error
+
+    expect {
+      described_class.new(operand_five, six)
+    }.not_to raise_error
+  end
 end


### PR DESCRIPTION
Fix #297 

Arithmetic on custom classes was working as expected until the changes in https://github.com/rubysolo/dentaku/commit/2246cb99143fa9aedc896b3525a6f5b2050726a0 .. Given that the library already have existing test cases for this for some other data type and operation (e.g. array, addition with custom classes, etc); I think it make sense to make sure that other operations are also working as expected..