### PR TITLE
Support quoted identifiers

### DIFF
--- a/lib/dentaku/token_scanner.rb
+++ b/lib/dentaku/token_scanner.rb
@@ -51,7 +51,8 @@ module Dentaku
           :comparator,
           :boolean,
           :function,
-          :identifier
+          :identifier,
+          :quoted_identifier
         ]
       end
 
@@ -179,6 +180,10 @@ module Dentaku
 
       def identifier
         new(:identifier, '[[[:word:]]\.]+\b', lambda { |raw| standardize_case(raw.strip) })
+      end
+
+      def quoted_identifier
+        new(:identifier, '`[^`]*`', lambda { |raw| raw.gsub(/^`|`$/, '') })
       end
     end
 


### PR DESCRIPTION
The identifiers may include spaces and other characters that are usually operators. Like `-`. This is a common use case in SQL and any other arithmatic library. This change adds support of quoted identifiers which uses backticks for quotes.