### PR TITLE
Fix function IF dependencies when predicate value evaluation raises error

### DIFF
--- a/lib/dentaku/ast/functions/if.rb
+++ b/lib/dentaku/ast/functions/if.rb
@@ -39,10 +39,16 @@ module Dentaku
         deps = predicate.dependencies(context)
 
         if deps.empty?
-          predicate.value(context) ? left.dependencies(context) : right.dependencies(context)
-        else
-          (deps + left.dependencies(context) + right.dependencies(context)).uniq
+          begin
+            value = predicate.value(context)
+            evaluated = true
+          rescue Dentaku::Error, Dentaku::ArgumentError, Dentaku::ZeroDivisionError
+            evaluated = false
+          end
+          return value ? left.dependencies(context) : right.dependencies(context) if evaluated
         end
+
+        (deps + left.dependencies(context) + right.dependencies(context)).uniq
       end
     end
   end

--- a/spec/bulk_expression_solver_spec.rb
+++ b/spec/bulk_expression_solver_spec.rb
@@ -197,5 +197,16 @@ RSpec.describe Dentaku::BulkExpressionSolver do
       expect(results).to eq('key' => [3, :undefined])
       expect { solver.solve! }.to raise_error(Dentaku::UnboundVariableError)
     end
+
+    it do
+      calculator.store(val: nil)
+      expressions = {
+        a: 'IF(5 / 0 > 0, 100, 1000)',
+        b: 'IF(val = 0, 0, IF(val > 0, 0, 0))'
+      }
+      solver = described_class.new(expressions, calculator)
+      results = solver.solve
+      expect(results).to eq(a: :undefined, b: :undefined)
+    end
   end
 end


### PR DESCRIPTION
When resolving bulk expressions and `IF` function contains comparison expression, but variable value is nil, then dependencies calculation raises error, e.g. *Dentaku::AST::GreaterThan requires operands that respond to >* .

Similar issue was reported https://github.com/rubysolo/dentaku/issues/301 when expression raises ZeroDivisionError.

This error was introduced with [commit](https://github.com/rubysolo/dentaku/commit/b79a366299d4fcf8917e828713591451b4877251) to improve dependencies evaluation. I updated the code that when predicate value evaluation fails, then both dependencies are added like previously.

