### PR TITLE
fix case syntax link using text fragment

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Logic: `IF`, `AND`, `OR`, `XOR`, `NOT`, `SWITCH`
 
 Numeric: `MIN`, `MAX`, `SUM`, `AVG`, `COUNT`, `ROUND`, `ROUNDDOWN`, `ROUNDUP`, `ABS`, `INTERCEPT`
 
-Selections: `CASE` (syntax see [spec](https://github.com/rubysolo/dentaku/blob/master/spec/calculator_spec.rb#L593))
+Selections: `CASE` (syntax see [spec](https://github.com/rubysolo/dentaku/blob/main/spec/calculator_spec.rb#:~:text=CASE fruit))
 
 String: `LEFT`, `RIGHT`, `MID`, `LEN`, `FIND`, `SUBSTITUTE`, `CONCAT`, `CONTAINS`
 


### PR DESCRIPTION
link to specific line got broken and will get broken, using link to file at specific commit is probably not good, so either using a text fragment (this PR), which for me works half the time or putting an example of usage in for example the case node class documentation (#319)