### PR TITLE
fix case syntax linking to file with example in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Logic: `IF`, `AND`, `OR`, `XOR`, `NOT`, `SWITCH`
 
 Numeric: `MIN`, `MAX`, `SUM`, `AVG`, `COUNT`, `ROUND`, `ROUNDDOWN`, `ROUNDUP`, `ABS`, `INTERCEPT`
 
-Selections: `CASE` (syntax see [spec](https://github.com/rubysolo/dentaku/blob/master/spec/calculator_spec.rb#L593))
+Selections: `CASE` (syntax see [spec](https://github.com/rubysolo/dentaku/blob/main/lib/dentaku/ast/case.rb))
 
 String: `LEFT`, `RIGHT`, `MID`, `LEN`, `FIND`, `SUBSTITUTE`, `CONCAT`, `CONTAINS`
 

--- a/lib/dentaku/ast/case.rb
+++ b/lib/dentaku/ast/case.rb
@@ -7,6 +7,18 @@ require 'dentaku/exceptions'
 
 module Dentaku
   module AST
+    # Examples of using in a formula:
+    #
+    #     CASE x WHEN 1 THEN 2 WHEN 3 THEN 4 ELSE END
+    #
+    #     CASE fruit
+    #     WHEN 'apple'
+    #       THEN 1 * quantity
+    #     WHEN 'banana'
+    #       THEN 2 * quantity
+    #     ELSE
+    #       3 * quantity
+    #     END
     class Case < Node
       attr_reader :switch, :conditions, :else
 


### PR DESCRIPTION
link to specific line got broken and will get broken, using link to file at specific commit is probably not good, so either using a text fragment (#318), which for me works half the time or putting an example of usage in for example the case node class documentation (this PR)