### PR TITLE
Fix various issue with array arithmetic

### DIFF
--- a/lib/dentaku/ast/arithmetic.rb
+++ b/lib/dentaku/ast/arithmetic.rb
@@ -9,20 +9,6 @@ module Dentaku
       DECIMAL = /\A-?\d*\.\d+\z/.freeze
       INTEGER = /\A-?\d+\z/.freeze
 
-      def initialize(*)
-        super
-
-        unless valid_left?
-          raise NodeError.new(:numeric, left.type, :left),
-                "#{self.class} requires numeric operands"
-        end
-
-        unless valid_right?
-          raise NodeError.new(:numeric, right.type, :right),
-                "#{self.class} requires numeric operands"
-        end
-      end
-
       def type
         :numeric
       end
@@ -69,8 +55,9 @@ module Dentaku
       def datetime?(val)
         # val is a Date, Time, or DateTime
         return true if val.respond_to?(:strftime)
+        return false unless val.is_a?(::String)
 
-        val.to_s =~ Dentaku::TokenScanner::DATE_TIME_REGEXP
+        val =~ Dentaku::TokenScanner::DATE_TIME_REGEXP
       end
 
       def valid_node?(node)

--- a/spec/ast/addition_spec.rb
+++ b/spec/ast/addition_spec.rb
@@ -20,22 +20,21 @@ describe Dentaku::AST::Addition do
     expect(node.value).to eq(11)
   end
 
-  it 'requires numeric operands' do
+  it 'requires operands that respond to +' do
     expect {
-      described_class.new(five, t)
-    }.to raise_error(Dentaku::NodeError, /requires numeric operands/)
+      described_class.new(five, t).value
+    }.to raise_error(Dentaku::ArgumentError, /requires operands that respond to +/)
 
     expression = Dentaku::AST::Multiplication.new(five, five)
     group = Dentaku::AST::Grouping.new(expression)
 
     expect {
-      described_class.new(group, five)
+      described_class.new(group, five).value
     }.not_to raise_error
   end
 
   it 'allows operands that respond to addition' do
     # Sample struct that has a custom definition for addition
-
     Addable = Struct.new(:value) do
       def +(other)
         case other
@@ -51,12 +50,18 @@ describe Dentaku::AST::Addition do
     operand_six = Dentaku::AST::Numeric.new Dentaku::Token.new(:numeric, Addable.new(6))
 
     expect {
-      described_class.new(operand_five, operand_six)
+      described_class.new(operand_five, operand_six).value
     }.not_to raise_error
 
     expect {
-      described_class.new(operand_five, six)
+      described_class.new(operand_five, six).value
     }.not_to raise_error
+  end
 
+  it 'does not try to parse nested string as date' do
+    a = ['2017-01-01', '2017-01-02']
+    b = ['2017-01-01']
+
+    expect(Dentaku('a + b', a: a, b: b)).to eq(['2017-01-01', '2017-01-02', '2017-01-01'])
   end
 end

--- a/spec/ast/arithmetic_spec.rb
+++ b/spec/ast/arithmetic_spec.rb
@@ -111,6 +111,13 @@ describe Dentaku::AST::Arithmetic do
     end
   end
 
+  it 'does not try to parse nested string as date' do
+    a = ['2017-01-01', '2017-01-02']
+    b = ['2017-01-01']
+
+    expect(Dentaku('a - b', a: a, b: b)).to eq(['2017-01-02'])
+  end
+
   it 'raises ArgumentError if given individually valid but incompatible arguments' do
     expect { add(one, date) }.to raise_error(Dentaku::ArgumentError)
     expect { add(x, one, 'x' => [1]) }.to raise_error(Dentaku::ArgumentError)

--- a/spec/ast/division_spec.rb
+++ b/spec/ast/division_spec.rb
@@ -20,16 +20,16 @@ describe Dentaku::AST::Division do
     expect(node.value.round(4)).to eq(0.8333)
   end
 
-  it 'requires numeric operands' do
+  it 'requires operands that respond to /' do
     expect {
-      described_class.new(five, t)
-    }.to raise_error(Dentaku::NodeError, /requires numeric operands/)
+      described_class.new(five, t).value
+    }.to raise_error(Dentaku::ArgumentError, /requires operands that respond to \//)
 
     expression = Dentaku::AST::Multiplication.new(five, five)
     group = Dentaku::AST::Grouping.new(expression)
 
     expect {
-      described_class.new(group, five)
+      described_class.new(group, five).value
     }.not_to raise_error
   end
 
@@ -44,17 +44,21 @@ describe Dentaku::AST::Division do
           value + other
         end
       end
+
+      def zero?
+        value.zero?
+      end
     end
 
     operand_five = Dentaku::AST::Numeric.new Dentaku::Token.new(:numeric, Divisible.new(5))
     operand_six = Dentaku::AST::Numeric.new Dentaku::Token.new(:numeric, Divisible.new(6))
 
     expect {
-      described_class.new(operand_five, operand_six)
+      described_class.new(operand_five, operand_six).value
     }.not_to raise_error
 
     expect {
-      described_class.new(operand_five, six)
+      described_class.new(operand_five, six).value
     }.not_to raise_error
   end
 end

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -77,11 +77,17 @@ describe Dentaku::Parser do
   end
 
   it 'evaluates arrays' do
+    node = parse('{}')
+    expect(node.value).to eq([])
+
     node = parse('{1, 2, 3}')
     expect(node.value).to eq([1, 2, 3])
 
-    node = parse('{}')
-    expect(node.value).to eq([])
+    node = parse('{1, 2, 3} + {4,5,6}')
+    expect(node.value).to eq([1, 2, 3, 4, 5, 6])
+
+    node = parse('{1, 2, 3} - {2,3}')
+    expect(node.value).to eq([1])
   end
 
   context 'invalid expression' do


### PR DESCRIPTION
- should work with explicit arrays
- should not crash when it has deeply a string that looks like date

Without the fix:

```irb
> calculator.evaluate!("{1,2,3} + {4,5,6}")
Dentaku::ParseError: Dentaku::AST::Addition requires numeric operands, but got  (Dentaku::ParseError)
/dentaku-3.5.4/lib/dentaku/parser.rb:356:in `fail!'
Caused by Dentaku::NodeError: Dentaku::AST::Addition requires numeric operands
/dentaku-3.5.4/lib/dentaku/ast/arithmetic.rb:16:in `initialize'

> calculator.evaluate!("{1,2,3} - {1,2}")
Dentaku::ParseError: Dentaku::AST::Subtraction requires numeric operands, but got  (Dentaku::ParseError)
/dentaku-3.5.4/lib/dentaku/parser.rb:356:in `fail!'
Caused by Dentaku::NodeError: Dentaku::AST::Subtraction requires numeric operands
/dentaku-3.5.4/lib/dentaku/ast/arithmetic.rb:16:in `initialize'

> calculator.evaluate!("a + b", { a: ['2017-01-01'], b: ['2017-01-01'] })
TypeError: no implicit conversion of Array into String (TypeError)

      d = Date._parse(date, comp)
                      ^^^^^^^^^^
/ruby-3.3.8/lib/ruby/3.3.0/time.rb:383:in `_parse'
```
