### PR TITLE
handle modulo zero same way as division by zero

### DIFF
--- a/lib/dentaku/ast/arithmetic.rb
+++ b/lib/dentaku/ast/arithmetic.rb
@@ -193,6 +193,13 @@ module Dentaku
       def operator
         :%
       end
+
+      def value(context = {})
+        r = decimal(cast(right.value(context)))
+        raise Dentaku::ZeroDivisionError if r.zero?
+
+        cast(cast(left.value(context)) % r)
+      end
     end
 
     class Percentage < Arithmetic

--- a/spec/bulk_expression_solver_spec.rb
+++ b/spec/bulk_expression_solver_spec.rb
@@ -33,8 +33,15 @@ RSpec.describe Dentaku::BulkExpressionSolver do
       }.to raise_error(Dentaku::UnboundVariableError)
     end
 
-    it "lets you know if the result is a div/0 error" do
+    it "lets you know if the result is a div/0 error when dividing" do
       expressions = {more_apples: "1/0"}
+      expect {
+        described_class.new(expressions, calculator).solve!
+      }.to raise_error(Dentaku::ZeroDivisionError)
+    end
+
+    it "lets you know if the result is a div/0 error when taking modulo" do
+      expressions = {more_apples: "1%0"}
       expect {
         described_class.new(expressions, calculator).solve!
       }.to raise_error(Dentaku::ZeroDivisionError)


### PR DESCRIPTION
Currently `Dentaku::Calculator.new.evaluate('10 % 0')` will raise `ZeroDivisionError` instead of returning `nil`