### PR TITLE
Fix: empty function call parsing when multiple functions present

### DIFF
--- a/lib/dentaku/parser.rb
+++ b/lib/dentaku/parser.rb
@@ -87,9 +87,10 @@ module Dentaku
           i += 1
           next
         end
+
         token = input[i]
         lookahead = input[i + 1]
-        process_token(token, lookahead, i, input)
+        process_token(token, lookahead, i)
         i += 1
       end
 
@@ -114,7 +115,7 @@ module Dentaku
 
     private
 
-    def process_token(token, lookahead, index, tokens)
+    def process_token(token, lookahead, index)
       case token.category
       when :datetime      then output << AST::DateTime.new(token)
       when :numeric       then output << AST::Numeric.new(token)
@@ -134,7 +135,7 @@ module Dentaku
       when :array
         handle_array(token)
       when :grouping
-        handle_grouping(token, lookahead, tokens)
+        handle_grouping(token, lookahead, index)
       else
         fail! :not_implemented_token_category, token_category: token.category
       end
@@ -251,14 +252,13 @@ module Dentaku
       end
     end
 
-    def handle_grouping(token, lookahead, tokens)
+    def handle_grouping(token, lookahead, token_index)
       case token.value
       when :open
         if lookahead && lookahead.value == :close
           # empty grouping (e.g. function with zero arguments) — we trigger consume later
           # skip to the end
-          lookahead_index = tokens.index(lookahead)
-          @skip_indices << lookahead_index if lookahead_index
+          @skip_indices << token_index + 1
           arities.pop
           consume(0)
         else

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -52,6 +52,11 @@ describe Dentaku::Parser do
     expect(node.value).to eq(2)
   end
 
+  it 'parses multiple zero-argument functions in sequence' do
+    node = parse('count() + count()') # count() without arguments returns 0
+    expect(node.value).to eq(0)
+  end
+
   it 'represents formulas with variables' do
     node = parse('5 * x')
     expect { node.value }.to raise_error(Dentaku::UnboundVariableError)


### PR DESCRIPTION
## Purpose of PR
Fixes a parser bug where consecutive empty function calls (e.g., `func() + func()`) would fail due to incorrect token skipping. 
Uses token index-based skipping instead of token lookup to prevent conflicts.

### Why it broke
Functions with 0 arguments are consumed immediately, requiring the closing bracket to be skipped. Previously, the code searched the token list for `)`, which would always just find the first instance, `3.5.5` and prior, it would delete this from the list, which worked fine since than the next closing bracket would become the first. 
however, with the update to `3.5.6` instead of deleting this bracket, it now instead saves its index to be skipped, keeping it still in the same location in the list. This causes `func1() + func2()` to skip the first closing bracket twice.

### The Fix
Before we do anything, we always check if the `lookahead` is a closing bracket.
By doing so, we already confirmed that the next one is a closing backet. So rather than searching the index of this bracket in the list, we can just simply do the current node index + 1


### Changes
- replaced the index search in the tokens list with the current index + 1 
   (For this i removed the tokens list from the arguments, since the only use case was to find this index. and now that that is gone, this list is also not needed there anymore)
- added a test in the parser suite to capture this case

### Before & After
```py
Dentaku.evaluate("count() + count()")
```
**Before:** 
<img width="1225" height="504" alt="image" src="https://github.com/user-attachments/assets/03cf8c5c-9a26-49e4-a490-e15d66db3bb4" />

**After:** `0` (this is expected. count() with no arguments returns 0)
