### PR TITLE
Fix: create numeric parser to unify all numeric string conversions

### DIFF
--- a/lib/dentaku/ast/arithmetic.rb
+++ b/lib/dentaku/ast/arithmetic.rb
@@ -6,9 +6,6 @@ require 'bigdecimal/util'
 module Dentaku
   module AST
     class Arithmetic < Operation
-      DECIMAL = /\A-?\d*\.\d+\z/.freeze
-      INTEGER = /\A-?\d+\z/.freeze
-
       def initialize(*)
         super
 
@@ -49,15 +46,7 @@ module Dentaku
 
       def cast(val)
         validate_value(val)
-        numeric(val)
-      end
-
-      def numeric(val)
-        case val.to_s
-        when DECIMAL then decimal(val)
-        when INTEGER then val.to_i
-        else val
-        end
+        Dentaku::NumericParser.ensure_numeric(val) || val
       end
 
       def decimal(val)
@@ -114,7 +103,7 @@ module Dentaku
       end
 
       def validate_format(string)
-        unless string =~ /\A-?\d*(\.\d+)?\z/ && !string.empty?
+        unless Dentaku::NumericParser.match(string)
           raise Dentaku::ArgumentError.for(:invalid_value, value: string, for: BigDecimal),
                 "String input '#{string}' is not coercible to numeric"
         end

--- a/lib/dentaku/ast/comparators.rb
+++ b/lib/dentaku/ast/comparators.rb
@@ -28,10 +28,10 @@ module Dentaku
 
       def cast(val)
         return val unless val.is_a?(::String)
-        return val unless val.match?(Arithmetic::DECIMAL) || val.match?(Arithmetic::INTEGER)
+        return val unless Dentaku::NumericParser.match(val)
 
-        v = BigDecimal(val, Float::DIG + 1)
-        v = v.to_i if v.frac.zero?
+        v = Dentaku::NumericParser.parse_string(val)
+        v = v.to_i if v.is_a?(BigDecimal) && v.frac.zero?
         v
       end
 

--- a/lib/dentaku/ast/comparators.rb
+++ b/lib/dentaku/ast/comparators.rb
@@ -28,11 +28,8 @@ module Dentaku
 
       def cast(val)
         return val unless val.is_a?(::String)
-        return val unless Dentaku::NumericParser.match(val)
 
-        v = Dentaku::NumericParser.parse_string(val)
-        v = v.to_i if v.is_a?(BigDecimal) && v.frac.zero?
-        v
+        Dentaku::NumericParser.parse_string(val) || val
       end
 
       def validate_value(value)

--- a/lib/dentaku/ast/function.rb
+++ b/lib/dentaku/ast/function.rb
@@ -37,20 +37,6 @@ module Dentaku
       def self.registry
         @registry ||= FunctionRegistry.new
       end
-
-      # @return [Numeric] where possible it returns an Integer otherwise a BigDecimal.
-      # An Exception will be raised if a value is passed that cannot be cast to a Number.
-      def self.numeric(value)
-        return value if value.is_a?(::Numeric)
-
-        if value.is_a?(::String)
-          number = value[/\A-?\d*\.?\d+\z/]
-          return number.include?('.') ? BigDecimal(number, DIG) : number.to_i if number
-        end
-
-        raise Dentaku::ArgumentError.for(:incompatible_type, value: value, for: Numeric),
-          "'#{value || value.class}' is not coercible to numeric"
-      end
     end
   end
 end

--- a/lib/dentaku/ast/functions/abs.rb
+++ b/lib/dentaku/ast/functions/abs.rb
@@ -1,5 +1,5 @@
 require_relative '../function'
 
 Dentaku::AST::Function.register(:abs, :numeric, lambda { |numeric|
-  Dentaku::AST::Function.numeric(numeric).abs
+  Dentaku::NumericParser.ensure_numeric!(numeric).abs
 })

--- a/lib/dentaku/ast/functions/avg.rb
+++ b/lib/dentaku/ast/functions/avg.rb
@@ -9,5 +9,5 @@ Dentaku::AST::Function.register(:avg, :numeric, ->(*args) {
     ), 'AVG() requires at least one argument'
   end
 
-  flatten_args.map { |arg| Dentaku::AST::Function.numeric(arg) }.reduce(0, :+) / BigDecimal(flatten_args.length)
+  flatten_args.map { |arg| Dentaku::NumericParser.ensure_numeric!(arg) }.reduce(0, :+) / BigDecimal(flatten_args.length)
 })

--- a/lib/dentaku/ast/functions/intercept.rb
+++ b/lib/dentaku/ast/functions/intercept.rb
@@ -17,8 +17,8 @@ Dentaku::AST::Function.register(:intercept, :list, ->(*args) {
   end
 
   n = x_values.length.to_f
-  x_values = x_values.map { |arg| Dentaku::AST::Function.numeric(arg) }
-  y_values = y_values.map { |arg| Dentaku::AST::Function.numeric(arg) }
+  x_values = x_values.map { |arg| Dentaku::NumericParser.ensure_numeric!(arg) }
+  y_values = y_values.map { |arg| Dentaku::NumericParser.ensure_numeric!(arg) }
 
   x_avg = x_values.sum / n
   y_avg = y_values.sum / n

--- a/lib/dentaku/ast/functions/max.rb
+++ b/lib/dentaku/ast/functions/max.rb
@@ -1,5 +1,5 @@
 require_relative '../function'
 
 Dentaku::AST::Function.register(:max, :numeric, ->(*args) {
-  args.flatten.map { |arg| Dentaku::AST::Function.numeric(arg) }.max
+  args.flatten.map { |arg| Dentaku::NumericParser.ensure_numeric!(arg) }.max
 })

--- a/lib/dentaku/ast/functions/min.rb
+++ b/lib/dentaku/ast/functions/min.rb
@@ -1,5 +1,5 @@
 require_relative '../function'
 
 Dentaku::AST::Function.register(:min, :numeric, ->(*args) {
-  args.flatten.map { |arg| Dentaku::AST::Function.numeric(arg) }.min
+  args.flatten.map { |arg| Dentaku::NumericParser.ensure_numeric!(arg) }.min
 })

--- a/lib/dentaku/ast/functions/mul.rb
+++ b/lib/dentaku/ast/functions/mul.rb
@@ -8,5 +8,5 @@ Dentaku::AST::Function.register(:mul, :numeric, ->(*args) {
     ), 'MUL() requires at least one argument'
   end
 
-  args.flatten.map { |arg| Dentaku::AST::Function.numeric(arg) }.reduce(1, :*)
+  args.flatten.map { |arg| Dentaku::NumericParser.ensure_numeric!(arg) }.reduce(1, :*)
 })

--- a/lib/dentaku/ast/functions/round.rb
+++ b/lib/dentaku/ast/functions/round.rb
@@ -1,5 +1,5 @@
 require_relative '../function'
 
 Dentaku::AST::Function.register(:round, :numeric, lambda { |numeric, places = 0|
-  Dentaku::AST::Function.numeric(numeric).round(Dentaku::AST::Function.numeric(places || 0).to_i)
+  Dentaku::NumericParser.ensure_numeric!(numeric).round(Dentaku::NumericParser.ensure_numeric!(places || 0).to_i)
 })

--- a/lib/dentaku/ast/functions/rounddown.rb
+++ b/lib/dentaku/ast/functions/rounddown.rb
@@ -1,8 +1,8 @@
 require_relative '../function'
 
 Dentaku::AST::Function.register(:rounddown, :numeric, lambda { |numeric, precision = 0|
-  precision = Dentaku::AST::Function.numeric(precision || 0).to_i
+  precision = Dentaku::NumericParser.ensure_numeric!(precision || 0).to_i
   tens = 10.0**precision
-  result = (Dentaku::AST::Function.numeric(numeric) * tens).floor / tens
+  result = (Dentaku::NumericParser.ensure_numeric!(numeric) * tens).floor / tens
   precision <= 0 ? result.to_i : result
 })

--- a/lib/dentaku/ast/functions/roundup.rb
+++ b/lib/dentaku/ast/functions/roundup.rb
@@ -1,8 +1,8 @@
 require_relative '../function'
 
 Dentaku::AST::Function.register(:roundup, :numeric, lambda { |numeric, precision = 0|
-  precision = Dentaku::AST::Function.numeric(precision || 0).to_i
+  precision = Dentaku::NumericParser.ensure_numeric!(precision || 0).to_i
   tens = 10.0**precision
-  result = (Dentaku::AST::Function.numeric(numeric) * tens).ceil / tens
+  result = (Dentaku::NumericParser.ensure_numeric!(numeric) * tens).ceil / tens
   precision <= 0 ? result.to_i : result
 })

--- a/lib/dentaku/ast/functions/ruby_math.rb
+++ b/lib/dentaku/ast/functions/ruby_math.rb
@@ -39,7 +39,7 @@ module Dentaku
       end
 
       def value(context = {})
-        args = @args.flatten.map { |a| Dentaku::AST::Function.numeric(a.value(context)) }
+        args = @args.flatten.map { |a|Dentaku::NumericParser.ensure_numeric!(a.value(context)) }
         self.class.call(*args)
       end
 

--- a/lib/dentaku/ast/functions/string_functions.rb
+++ b/lib/dentaku/ast/functions/string_functions.rb
@@ -32,7 +32,7 @@ module Dentaku
 
         def value(context = {})
           string = @string.value(context).to_s
-          length = Dentaku::AST::Function.numeric(@length.value(context)).to_i
+          length = Dentaku::NumericParser.ensure_numeric!(@length.value(context)).to_i
           negative_argument_failure('LEFT') if length < 0
           string[0, length]
         end
@@ -54,7 +54,7 @@ module Dentaku
 
         def value(context = {})
           string = @string.value(context).to_s
-          length = Dentaku::AST::Function.numeric(@length.value(context)).to_i
+          length = Dentaku::NumericParser.ensure_numeric!(@length.value(context)).to_i
           negative_argument_failure('RIGHT') if length < 0
           string[length * -1, length] || string
         end
@@ -76,9 +76,9 @@ module Dentaku
 
         def value(context = {})
           string = @string.value(context).to_s
-          offset = Dentaku::AST::Function.numeric(@offset.value(context)).to_i
+          offset = Dentaku::NumericParser.ensure_numeric!(@offset.value(context)).to_i
           negative_argument_failure('MID', 'offset') if offset < 0
-          length = Dentaku::AST::Function.numeric(@length.value(context)).to_i
+          length = Dentaku::NumericParser.ensure_numeric!(@length.value(context)).to_i
           negative_argument_failure('MID') if length < 0
           string[offset - 1, length].to_s
         end

--- a/lib/dentaku/ast/functions/sum.rb
+++ b/lib/dentaku/ast/functions/sum.rb
@@ -8,5 +8,5 @@ Dentaku::AST::Function.register(:sum, :numeric, ->(*args) {
     ), 'SUM() requires at least one argument'
   end
 
-  args.flatten.map { |arg| Dentaku::AST::Function.numeric(arg) }.reduce(0, :+)
+  args.flatten.map { |arg| Dentaku::NumericParser.ensure_numeric!(arg) }.reduce(0, :+)
 })

--- a/lib/dentaku/numeric_parser.rb
+++ b/lib/dentaku/numeric_parser.rb
@@ -1,0 +1,68 @@
+module Dentaku
+  module NumericParser
+    NUMERIC_PATTERN = '((?:\d+(\.\d+)?|\.\d+)(?:(e|E)(\+|-)?\d+)?)\b'.freeze
+    # e.g:  [2, 1.2, .5, 1e10, 1.5E-10]
+    HEXADECIMAL_PATTERN = '(0x[0-9a-f]+)\b'.freeze
+    # e.g:  [0x1A3F]
+
+    class << self
+      def match(string)
+        regex = %r{\A(-?(#{ NUMERIC_PATTERN }|#{ HEXADECIMAL_PATTERN }))\z}i
+        string.match(regex)
+      end
+
+      def match_numeric(string)
+        regex = %r{\A(#{ NUMERIC_PATTERN })\z}i
+        string.match(regex)
+      end
+
+      def match_hexadecimal(string)
+        regex = %r{\A(#{ HEXADECIMAL_PATTERN })\z}i
+        string.match(regex)
+      end
+
+      def parse_numeric_string(raw)
+        raw =~ /(\.|e|E)/ ? BigDecimal(raw, Float::DIG + 1) : raw.to_i
+      end
+
+      def parse_hexadecimal_string(raw)
+        raw[2..-1].to_i(16)
+      end
+
+      def parse_string(raw)
+        return nil unless !!match(raw)
+
+        is_negative = raw.start_with?('-')
+        number_part = is_negative ? raw[1..-1] : raw
+
+        value = if number_part =~ /\A0x/i
+          parse_hexadecimal_string(number_part)
+        else
+          parse_numeric_string(number_part)
+        end
+
+        is_negative ? -value : value
+      end
+
+      # @return [Numeric] where possible it returns an Integer otherwise a BigDecimal.
+      # An Exception will be raised if a value is passed that cannot be cast to a Number.
+      def ensure_numeric!(value)
+        return value if value.is_a?(::Numeric)
+
+        if value.is_a?(::String)
+          number = parse_string(value)
+          return number if number
+        end
+
+        raise Dentaku::ArgumentError.for(:incompatible_type, value: value, for: Numeric),
+          "'#{value || value.class}' is not coercible to numeric"
+      end
+
+      def ensure_numeric(value)
+        ensure_numeric!(value)
+      rescue Dentaku::ArgumentError
+        nil
+      end
+    end
+  end
+end

--- a/lib/dentaku/token_scanner.rb
+++ b/lib/dentaku/token_scanner.rb
@@ -2,6 +2,7 @@ require 'bigdecimal'
 require 'time'
 require 'dentaku/string_casing'
 require 'dentaku/token'
+require 'dentaku/numeric_parser'
 
 module Dentaku
   class TokenScanner
@@ -95,13 +96,11 @@ module Dentaku
       end
 
       def numeric
-        new(:numeric, '((?:\d+(\.\d+)?|\.\d+)(?:(e|E)(\+|-)?\d+)?)\b', lambda { |raw|
-          raw =~ /(\.|e|E)/ ? BigDecimal(raw) : raw.to_i
-        })
+        new(:numeric, NumericParser::NUMERIC_PATTERN, lambda { |raw| NumericParser.parse_numeric_string(raw) })
       end
 
       def hexadecimal
-        new(:numeric, '(0x[0-9a-f]+)\b', lambda { |raw| raw[2..-1].to_i(16) })
+        new(:numeric, NumericParser::HEXADECIMAL_PATTERN, lambda { |raw| NumericParser.parse_hexadecimal_string(raw) })
       end
 
       def double_quoted_string

--- a/spec/ast/function_spec.rb
+++ b/spec/ast/function_spec.rb
@@ -37,31 +37,6 @@ describe Dentaku::AST::Function do
     end
   end
 
-  it 'casts a String to an Integer if possible' do
-    expect(described_class.numeric('3')).to eq(3)
-  end
-
-  it 'casts a String to a BigDecimal if possible and if Integer would loose information' do
-    expect(described_class.numeric('3.2')).to eq(3.2)
-  end
-
-  it 'casts a String to a BigDecimal with a negative number' do
-    expect(described_class.numeric('-3.2')).to eq(-3.2)
-  end
-
-  it 'casts a String to a BigDecimal without a leading zero' do
-    expect(described_class.numeric('-.2')).to eq(-0.2)
-  end
-
-  it 'raises an error if the value could not be cast to a Numeric' do
-    expect { described_class.numeric('flarble') }.to raise_error Dentaku::ArgumentError
-    expect { described_class.numeric('-') }.to raise_error Dentaku::ArgumentError
-    expect { described_class.numeric('') }.to raise_error Dentaku::ArgumentError
-    expect { described_class.numeric(nil) }.to raise_error Dentaku::ArgumentError
-    expect { described_class.numeric('7.') }.to raise_error Dentaku::ArgumentError
-    expect { described_class.numeric(true) }.to raise_error Dentaku::ArgumentError
-  end
-
   it "allows read access to arguments" do
     fn = described_class.new(1, 2, 3)
     expect(fn.args).to eq([1, 2, 3])

--- a/spec/numeric_parser_spec.rb
+++ b/spec/numeric_parser_spec.rb
@@ -1,0 +1,66 @@
+require 'dentaku/numeric_parser'
+
+describe Dentaku::NumericParser do
+  it 'casts a String to an Integer if possible' do
+    result = Dentaku::NumericParser.ensure_numeric!('3')
+    expect(result).to eq(3)
+    expect(result).to be_a(Integer)
+  end
+
+  it 'casts a String to a BigDecimal if possible and if Integer would loose information' do
+    result = Dentaku::NumericParser.ensure_numeric!('3.2')
+    expect(result).to eq(3.2)
+    expect(result).to be_a(BigDecimal)
+  end
+
+  it 'casts a String to a BigDecimal with a negative number' do
+    result = Dentaku::NumericParser.ensure_numeric!('-3.2')
+    expect(result).to eq(-3.2)
+    expect(result).to be_a(BigDecimal)
+  end
+
+  it 'casts a String to a BigDecimal without a leading zero' do
+    result = Dentaku::NumericParser.ensure_numeric!('-.2')
+    expect(result).to eq(-0.2)
+    expect(result).to be_a(BigDecimal)
+  end
+
+  it 'casts a String with Sientific notiation to a BigDecimal' do
+    result = Dentaku::NumericParser.ensure_numeric!('12E1')
+    expect(result).to eq(12e1)
+    expect(result).to be_a(BigDecimal)
+  end
+
+  it 'casts a String with negative Sientific notiation to a BigDecimal' do
+    result = Dentaku::NumericParser.ensure_numeric!('12e-2')
+    expect(result).to eq(0.12)
+    expect(result).to be_a(BigDecimal)
+  end
+
+  it 'casts a String with hexadecimal to an Integer' do
+    result1 = Dentaku::NumericParser.ensure_numeric!('0xFFD')
+    result2 = Dentaku::NumericParser.ensure_numeric!('0x00000001')
+    expect(result1).to eq(4093)
+    expect(result2).to eq(1)
+    expect(result1).to be_a(Integer)
+    expect(result2).to be_a(Integer)
+  end
+
+  it 'casts a String with a negative hexadecimal to an Integer' do
+    result = Dentaku::NumericParser.ensure_numeric!('-0xFF')
+    expect(result).to eq(-0xFF)
+    expect(result).to be_a(Integer)
+  end
+
+  it 'raises an error if the value could not be cast to a Numeric' do
+    expect { Dentaku::NumericParser.ensure_numeric!('flarble') }.to raise_error Dentaku::ArgumentError
+    expect { Dentaku::NumericParser.ensure_numeric!('-') }.to raise_error Dentaku::ArgumentError
+    expect { Dentaku::NumericParser.ensure_numeric!('') }.to raise_error Dentaku::ArgumentError
+    expect { Dentaku::NumericParser.ensure_numeric!(nil) }.to raise_error Dentaku::ArgumentError
+    expect { Dentaku::NumericParser.ensure_numeric!('7.') }.to raise_error Dentaku::ArgumentError
+    expect { Dentaku::NumericParser.ensure_numeric!(true) }.to raise_error Dentaku::ArgumentError
+    expect { Dentaku::NumericParser.ensure_numeric!("1 - 2") }.to raise_error Dentaku::ArgumentError
+    expect { Dentaku::NumericParser.ensure_numeric!([1]) }.to raise_error Dentaku::ArgumentError
+    expect { Dentaku::NumericParser.ensure_numeric!("1f") }.to raise_error Dentaku::ArgumentError
+  end
+end


### PR DESCRIPTION
## Purpose of PR
Within the codebase there are a total of 4 different locations where string to number parsing and conversion is being done. And they also all work differently. Some support numbers like `2.4e3` and `0xE1FA`, but others rnot.
This PR is an attempt at unifying the number conversion within Dentaku.

**Changes:**
 - I created a `NumericParser` class that does the number pattern matching and conversion.
 - I replaced all the locations within Dentaku that had their own variant of this conversion with the `NumericParser` . 
    I made sure that intended  differences between the 4 places stayed in tact  such that the existing behavior does not change. 
    (e.g. `Function.numeric` throws if it can't convert it, while `Arithmetic.numeric` just returns original value if it cant conversion it. )
- With this new unified Parser, everywhere we try to parse a string in to a number, all the supported number types are supported. no matter where you try it
   And when adding a conversion somewhere else, if they use the `NumericParser` we can guarantee that they will also get the full list of supported numbers
   
## What is the state before / Inconsistencies that this PR solves
The 4 different locations are
1. **[TokenScanner](https://github.com/rubysolo/dentaku/blob/78a2fa3dff9cbfd7c8ce625b55fe23f12b21ceb0/lib/dentaku/token_scanner.rb#L97C6-L105C10):** Most extensive one of the 4. Parsers all numbers we support (since it defines what we do and do not support).  Also numbers like `2.4e3` and `0xE1FA`
2. **[Function](https://github.com/rubysolo/dentaku/blob/78a2fa3dff9cbfd7c8ce625b55fe23f12b21ceb0/lib/dentaku/ast/function.rb#L43C4-L53C10):** It returns the value unchanged if it's already numeric. If it's a string, it attempts to parse it. Choosing BigDecimal when it matches an Decimal form and Integer otherwise. If parsing fails, it throws.
3. **[Arithmetic](https://github.com/rubysolo/dentaku/blob/78a2fa3dff9cbfd7c8ce625b55fe23f12b21ceb0/lib/dentaku/ast/arithmetic.rb#L55C1-L61C10):** It converts the value to a string and checks whether that string represents an integer or decimal. If so, it returns the parsed number. If not, it returns the original value.
4. **[Comparator](https://github.com/rubysolo/dentaku/blob/78a2fa3dff9cbfd7c8ce625b55fe23f12b21ceb0/lib/dentaku/ast/comparators.rb#L29C6-L36C10):** it checks if it is a string, and if it can be converted (in either a decimal or Integer). But then it converts it in to a BigDecimal regardless of whether the string exhibits decimal traits or if its just an Integer. Than after the conversion it checks if there is a fractional part, if not it converts it in to an Int.

These independent rules lead to inconsistencies, some of which are more apparent than others.
-  most obvious, we cant use the more specific number formats as a strings. 
    `avg(10)` => `10`  
    `avg("10")` => `10`  
    `avg(0.1e2)` => `10`  
    `avg("0.1e2")` => `nil`  
    `avg(0xFF)` => `255`  
    `avg("0xFF")` => `nil`
- the `Function` and `Arithmetic` seem to somewhat do the same thing. Convert the string-number to a real number such that it can be used to perform math stuff.
   But it works different. `Function` first checks if its numeric and only after that tries to convert the string. While `Arithmetic` just checks it string representation right away, and returns the original value as fallback.
   In both cases, this has pretty much identical outcome. also for more complex native numeric like `Rational` or `Complex`. The inconsistency lies in when someone wants to create their own custom Numeric class/object. they all of a sudden are struck that if they want to make it work in all cases, they have to implement numeric, while also making sure that `.to_s` does or does **not** return a convertible representation. since if they do, they might lose information.
- From my deep dive i can see that the `Comparator`  class compares the numeric interpretation of a string rather than the stringified version of a number. That also justifies why `"1" == "1.0"` evaluates to `true`. Looking at the code, it always attempts to parse a string into a number and only falls back to the raw string when it cant. It also always produces a `BigDecimal ` first, and then down casts to Integer if that can be done without losing information. The intent seems to be preserving cases like `"1.0" == 1`, but Ruby’s own comparison already handles this correctly: `BigDecimal("1.0") == 1` is `true` without any extra coercion (ruby tries to coerce when it cant do an operant).

## What can we do now
In short, strings now can be converted to numbers of all the supported number types that we already supported in expressions.
E.g.
```py
Dentaku.evaluate('avg("0xFF") + 1') # returns 256
```
```py
Dentaku.evaluate('"10e-4" < 5e2') # returns true
```


I also left a few comments throughout the code that talk about specific parts of the PR
