### PR TITLE
Add tsort to dependency for Ruby 4.1

### DIFF
--- a/dentaku.gemspec
+++ b/dentaku.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('bigdecimal')
   s.add_dependency('concurrent-ruby')
+  s.add_dependency('tsort')
 
   s.add_development_dependency('pry')
   s.add_development_dependency('pry-byebug')


### PR DESCRIPTION
`tsort` was moved out of Ruby standard library since Ruby 4.1 by https://github.com/ruby/ruby/pull/15825

This PR explicitly adds dependency to `tsort` to address the following error when testing against Ruby head (4.1.0dev): https://github.com/david942j/gdb-ruby/pull/127

```
/Users/runner/work/gdb-ruby/gdb-ruby/vendor/bundle/ruby/4.1.0+1/gems/dentaku-3.5.6/lib/dentaku/dependency_resolver.rb:1: warning: tsort used to be loaded from the standard library, but is not part of the default gems since Ruby 4.1.0.
You can add tsort to your Gemfile or gemspec to fix this error.
```