### PR TITLE
Fix: whitespace between alias function name results in failure

### DIFF
--- a/lib/dentaku/tokenizer.rb
+++ b/lib/dentaku/tokenizer.rb
@@ -83,7 +83,7 @@ module Dentaku
 
     def alias_regex
       values = @aliases.values.flatten.join('|')
-      /(?<=\p{Punct}|[[:space:]]|\A)(#{values})(?=\()/i
+      /(?<=\p{Punct}|[[:space:]]|\A)(#{values})(?=\s*\()/i
     end
 
     private

--- a/spec/calculator_spec.rb
+++ b/spec/calculator_spec.rb
@@ -961,9 +961,19 @@ describe Dentaku::Calculator do
     end
   end
 
+  describe 'functions with whitespace before parentheses' do
+    it 'accepts regular functions' do
+      expect(calculator.evaluate('round (5.1)')).to eq(5)
+    end
+  end
+
   describe 'aliases' do
     it 'accepts aliases as instance option' do
       expect(with_aliases.evaluate('rrround(5.1)')).to eq(5)
+    end
+
+    it 'accepts aliases with whitespace before parentheses' do
+      expect(with_aliases.evaluate('rrround (5.1)')).to eq(5)
     end
   end
 

--- a/spec/tokenizer_spec.rb
+++ b/spec/tokenizer_spec.rb
@@ -360,6 +360,12 @@ describe Dentaku::Tokenizer do
       expect(tokenizer.replace_aliases(input)).to eq('min(4,6,2)')
     end
 
+    it 'replaces aliases with whitespace before parentheses' do
+      input = 'rrrrround! (8.2) + minimo (4,6,2)'
+      tokenizer.tokenize(input, aliases: aliases)
+      expect(tokenizer.replace_aliases(input)).to eq('round (8.2) + min (4,6,2)')
+    end
+
     it 'replace only whole aliases without word parts' do
       input = 'maximo(2,minimoooo())' # `minimoooo` doesn't match `minimo`
       tokenizer.tokenize(input, aliases: aliases)


### PR DESCRIPTION
## Purpose of PR
 Alias functions could not be called with whitespace between the function name and the opening bracket.

  This happened because normal functions and aliases were not handled the same way.
  Normal functions already support optional whitespace before `(` in the tokenizer, so `round (5.1)` was parsed
  correctly.

  But aliases are first rewritten to their real function name before tokenizing, and that alias-matching regex
  only matched when `(` came immediately after the alias name.
  So `rrround(5.1)` was rewritten to `round(5.1)`, but `rrround (5.1)` was not rewritten at all, which caused parsing
  to fail.

  This change makes alias handling consistent with normal function handling by allowing optional whitespace
  before `(` there as well

## Change
  - Updated the alias replacement regex to allow optional whitespace before `(`
  - Added tests to cover both normal functions and aliases with whitespace before the brackets

## Beofre & After
**Before:**
```py
cal = Dentaku::Calculator.new(aliases: { round: ['rrround'] })
cal.evaluate("round(5.1)")      # 5
cal.evaluate("rrround(5.1)")    # 5
cal.evaluate("round  (5.1)")    # 5
cal.evaluate("rrround  (5.1)")  # nil
```


**After:**
```py
cal = Dentaku::Calculator.new(aliases: { round: ['rrround'] })
cal.evaluate("round(5.1)")      # 5
cal.evaluate("rrround(5.1)")    # 5
cal.evaluate("round  (5.1)")    # 5
cal.evaluate("rrround  (5.1)")  # 5
```