### PR TITLE
Add HumanizeVisitor and Calculator#humanize

### DIFF
--- a/lib/dentaku/calculator.rb
+++ b/lib/dentaku/calculator.rb
@@ -2,6 +2,7 @@ require 'dentaku/bulk_expression_solver'
 require 'dentaku/dependency_resolver'
 require 'dentaku/exceptions'
 require 'dentaku/flat_hash'
+require 'dentaku/humanize_visitor'
 require 'dentaku/parser'
 require 'dentaku/string_casing'
 require 'dentaku/token'
@@ -104,6 +105,15 @@ module Dentaku
       else
         ast(expression).dependencies(test_context)
       end
+    end
+
+    # Returns a natural-language English representation of an expression.
+    # Optionally substitutes identifiers with values from `data`.
+    #
+    #   calculator.humanize("days >= min and days <= max", min: 5, max: 20)
+    #   # => "days is greater than or equal to 5 and days is less than or equal to 20"
+    def humanize(expression, data = {})
+      HumanizeVisitor.new(ast(expression), data).to_s
     end
 
     def ast(expression)

--- a/lib/dentaku/humanize_visitor.rb
+++ b/lib/dentaku/humanize_visitor.rb
@@ -1,0 +1,69 @@
+require 'dentaku/print_visitor'
+
+module Dentaku
+  # Visits an AST and produces a natural-language English representation of
+  # the expression. Operators are verbalized (`>=` -> "is greater than or
+  # equal to"), logical combinators are spaced as words, and identifiers can
+  # optionally be substituted with concrete values.
+  #
+  #   ast = Dentaku::Calculator.new.ast("days >= min AND days <= max")
+  #   Dentaku::HumanizeVisitor.new(ast, min: 5, max: 20).to_s
+  #   # => "days is greater than or equal to 5 and days is less than or equal to 20"
+  #
+  # Falls back to PrintVisitor behavior for nodes without a verbal mapping, so
+  # any expression that PrintVisitor handles is also handled here.
+  class HumanizeVisitor < PrintVisitor
+    OPERATOR_PHRASES = {
+      Dentaku::AST::Addition           => 'plus',
+      Dentaku::AST::Subtraction        => 'minus',
+      Dentaku::AST::Multiplication     => 'times',
+      Dentaku::AST::Division           => 'divided by',
+      Dentaku::AST::Modulo             => 'modulo',
+      Dentaku::AST::Exponentiation     => 'to the power of',
+      Dentaku::AST::Equal              => 'equals',
+      Dentaku::AST::NotEqual           => 'does not equal',
+      Dentaku::AST::LessThan           => 'is less than',
+      Dentaku::AST::LessThanOrEqual    => 'is less than or equal to',
+      Dentaku::AST::GreaterThan        => 'is greater than',
+      Dentaku::AST::GreaterThanOrEqual => 'is greater than or equal to',
+      Dentaku::AST::And                => 'and',
+      Dentaku::AST::Or                 => 'or',
+      Dentaku::AST::BitwiseAnd         => 'bitwise and',
+      Dentaku::AST::BitwiseOr          => 'bitwise or',
+      Dentaku::AST::BitwiseShiftLeft   => 'shifted left by',
+      Dentaku::AST::BitwiseShiftRight  => 'shifted right by',
+    }.freeze
+
+    def initialize(node, values = {})
+      @values = values.each_with_object({}) { |(k, v), h| h[k.to_s] = v }
+      super(node)
+    end
+
+    def visit_operation(node)
+      phrase = OPERATOR_PHRASES[node.class]
+      return super unless phrase
+
+      visit_operand(node.left, node.class.precedence, suffix: ' ', dir: :left) if node.left
+      @output << phrase
+      visit_operand(node.right, node.class.precedence, prefix: ' ', dir: :right) if node.right
+    end
+
+    def visit_negation(node)
+      @output << 'negative '
+      node.node.accept(self)
+    end
+
+    def visit_nil(_node)
+      @output << 'null'
+    end
+
+    def visit_identifier(node)
+      if @values.key?(node.identifier)
+        value = @values[node.identifier]
+        @output << (value.is_a?(::String) ? value.inspect : value.to_s)
+      else
+        super
+      end
+    end
+  end
+end

--- a/spec/humanize_visitor_spec.rb
+++ b/spec/humanize_visitor_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+require 'dentaku'
+require 'dentaku/humanize_visitor'
+
+describe Dentaku::HumanizeVisitor do
+  let(:calculator) { Dentaku::Calculator.new }
+
+  def humanize(expression, values = {})
+    described_class.new(calculator.ast(expression), values).to_s
+  end
+
+  it 'verbalizes comparison operators' do
+    expect(humanize('a >= 5')).to eq('a is greater than or equal to 5')
+    expect(humanize('a <= 5')).to eq('a is less than or equal to 5')
+    expect(humanize('a > 5')).to eq('a is greater than 5')
+    expect(humanize('a < 5')).to eq('a is less than 5')
+    expect(humanize('a = 5')).to eq('a equals 5')
+    expect(humanize('a != 5')).to eq('a does not equal 5')
+  end
+
+  it 'verbalizes logical combinators' do
+    repr = humanize('a >= 5 and a <= 10')
+    expect(repr).to eq('a is greater than or equal to 5 and a is less than or equal to 10')
+  end
+
+  it 'verbalizes arithmetic operators' do
+    expect(humanize('1 + 2')).to eq('1 plus 2')
+    expect(humanize('3 - 1')).to eq('3 minus 1')
+    expect(humanize('2 * 3')).to eq('2 times 3')
+    expect(humanize('10 / 2')).to eq('10 divided by 2')
+    expect(humanize('2 ^ 3')).to eq('2 to the power of 3')
+    expect(humanize('7 % 3')).to eq('7 modulo 3')
+  end
+
+  it 'verbalizes negation' do
+    expect(humanize('-a')).to eq('negative a')
+  end
+
+  it 'substitutes identifiers with provided values' do
+    expect(humanize('days >= min and days <= max', min: 5, max: 20))
+      .to eq('days is greater than or equal to 5 and days is less than or equal to 20')
+  end
+
+  it 'quotes string values used in substitution' do
+    expect(humanize('name = expected', expected: 'Buk')).to eq('name equals "Buk"')
+  end
+
+  it 'preserves identifiers that have no value' do
+    expect(humanize('a + b', a: 1)).to eq('1 plus b')
+  end
+
+  it 'verbalizes nil literal' do
+    expect(humanize('a = NULL')).to eq('a equals null')
+  end
+
+  it 'falls back to PrintVisitor behavior for unmapped nodes' do
+    # bitwise still uses words via our mapping
+    expect(humanize('1 & 2')).to eq('1 bitwise and 2')
+    # function calls retain their printed form
+    expect(humanize('IF(a = 1, "yes", "no")')).to eq('IF(a equals 1, "yes", "no")')
+  end
+
+  it 'is exposed via Calculator#humanize' do
+    result = calculator.humanize('days >= min and days <= max', min: 5, max: 20)
+    expect(result).to eq('days is greater than or equal to 5 and days is less than or equal to 20')
+  end
+end


### PR DESCRIPTION
Adds a visitor that produces a natural-language English representation of a Dentaku expression. Operators are verbalized (>= -> 'is greater than or equal to'), and identifiers can optionally be substituted with concrete values via a second argument to Calculator#humanize.

  calc = Dentaku::Calculator.new
  calc.humanize('days >= min and days <= max', min: 5, max: 20)
  # => 'days is greater than or equal to 5 and days is less than or equal to 20'

HumanizeVisitor subclasses PrintVisitor, so any expression PrintVisitor handles is also handled here; only operator output is overridden.