### PR TITLE
Add HumanizeVisitor and Calculator#humanize

### DIFF
--- a/lib/dentaku/calculator.rb
+++ b/lib/dentaku/calculator.rb
@@ -5,6 +5,7 @@ require 'dentaku/flat_hash'
 require 'dentaku/parser'
 require 'dentaku/string_casing'
 require 'dentaku/token'
+require 'dentaku/humanize_visitor'
 
 module Dentaku
   class Calculator
@@ -104,6 +105,10 @@ module Dentaku
       else
         ast(expression).dependencies(test_context)
       end
+    end
+
+    def humanize(expression, data = {})
+      HumanizeVisitor.new(ast(expression), data).to_s
     end
 
     def ast(expression)

--- a/lib/dentaku/humanize_visitor.rb
+++ b/lib/dentaku/humanize_visitor.rb
@@ -1,0 +1,264 @@
+require 'dentaku/print_visitor'
+
+module Dentaku
+  class HumanizeVisitor < PrintVisitor
+    OPERATOR_PHRASES = {
+      Dentaku::AST::Addition           => 'plus',
+      Dentaku::AST::Subtraction        => 'minus',
+      Dentaku::AST::Multiplication     => 'times',
+      Dentaku::AST::Division           => 'divided by',
+      Dentaku::AST::Modulo             => 'modulo',
+      Dentaku::AST::Exponentiation     => 'to the power of',
+      Dentaku::AST::Equal              => 'equals',
+      Dentaku::AST::NotEqual           => 'does not equal',
+      Dentaku::AST::LessThan           => 'is less than',
+      Dentaku::AST::LessThanOrEqual    => 'is less than or equal to',
+      Dentaku::AST::GreaterThan        => 'is greater than',
+      Dentaku::AST::GreaterThanOrEqual => 'is greater than or equal to',
+      Dentaku::AST::And                => 'and',
+      Dentaku::AST::Or                 => 'or',
+      Dentaku::AST::BitwiseAnd         => 'bitwise and',
+      Dentaku::AST::BitwiseOr          => 'bitwise or',
+      Dentaku::AST::BitwiseShiftLeft   => 'shifted left by',
+      Dentaku::AST::BitwiseShiftRight  => 'shifted right by',
+    }.freeze
+
+    MATH_PHRASES = {
+      'SIN'    => [:unary,        'sine of'],
+      'COS'    => [:unary,        'cosine of'],
+      'TAN'    => [:unary,        'tangent of'],
+      'ASIN'   => [:unary,        'arcsine of'],
+      'ACOS'   => [:unary,        'arccosine of'],
+      'ATAN'   => [:unary,        'arctangent of'],
+      'SINH'   => [:unary,        'hyperbolic sine of'],
+      'COSH'   => [:unary,        'hyperbolic cosine of'],
+      'TANH'   => [:unary,        'hyperbolic tangent of'],
+      'ASINH'  => [:unary,        'inverse hyperbolic sine of'],
+      'ACOSH'  => [:unary,        'inverse hyperbolic cosine of'],
+      'ATANH'  => [:unary,        'inverse hyperbolic tangent of'],
+      'EXP'    => [:unary,        'e to the power of'],
+      'LOG2'   => [:unary,        'log base 2 of'],
+      'LOG10'  => [:unary,        'log base 10 of'],
+      'SQRT'   => [:unary,        'square root of'],
+      'CBRT'   => [:unary,        'cube root of'],
+      'ERF'    => [:unary,        'error function of'],
+      'ERFC'   => [:unary,        'complementary error function of'],
+      'GAMMA'  => [:unary,        'gamma function of'],
+      'LGAMMA' => [:unary,        'log-gamma of'],
+      'FREXP'  => [:unary,        'mantissa and exponent of'],
+      'ATAN2'  => [:binary_and,   'arctangent of'],
+      'HYPOT'  => [:binary_and,   'hypotenuse of'],
+      'LDEXP'  => [:binary_infix, 'times 2 to the power of'],
+      'LOG'    => [:log,          'logarithm of'],
+    }.freeze
+
+    def initialize(node, values = {})
+      @values = values.each_with_object({}) { |(k, v), h| h[k.to_s] = v }
+      super(node)
+    end
+
+    def visit_operation(node)
+      phrase = OPERATOR_PHRASES[node.class]
+      return super unless phrase
+
+      visit_operand(node.left,  node.class.precedence, suffix: ' ', dir: :left)  if node.left
+      @output << phrase
+      visit_operand(node.right, node.class.precedence, prefix: ' ', dir: :right) if node.right
+    end
+
+    def visit_function(node)
+      case node.name.to_s.upcase
+      when 'IF'        then humanize_if(node)
+      when 'AND'       then humanize_join(node.args, 'and')
+      when 'OR'        then humanize_join(node.args, 'or')
+      when 'XOR'       then humanize_join(node.args, 'exclusive-or')
+      when 'NOT'       then @output << 'not '; node.args[0].accept(self)
+      when 'SWITCH'    then humanize_switch(node)
+      when 'MIN'       then humanize_aggregate(node.args, 'minimum of')
+      when 'MAX'       then humanize_aggregate(node.args, 'maximum of')
+      when 'SUM'       then humanize_aggregate(node.args, 'sum of')
+      when 'AVG'       then humanize_aggregate(node.args, 'average of')
+      when 'COUNT'     then humanize_aggregate(node.args, 'count of')
+      when 'ABS'       then @output << 'absolute value of '; node.args[0].accept(self)
+      when 'ROUND'     then humanize_round(node, 'rounded')
+      when 'ROUNDUP'   then humanize_round(node, 'rounded up')
+      when 'ROUNDDOWN' then humanize_round(node, 'rounded down')
+      when 'INTERCEPT'
+        @output << 'linear intercept of '
+        node.args[0].accept(self); @output << ' and '; node.args[1].accept(self)
+      when 'LEFT'
+        @output << 'first '; node.args[1].accept(self)
+        @output << ' characters of '; node.args[0].accept(self)
+      when 'RIGHT'
+        @output << 'last '; node.args[1].accept(self)
+        @output << ' characters of '; node.args[0].accept(self)
+      when 'MID'
+        node.args[2].accept(self)
+        @output << ' characters of '; node.args[0].accept(self)
+        @output << ' starting at position '; node.args[1].accept(self)
+      when 'LEN'
+        @output << 'length of '; node.args[0].accept(self)
+      when 'FIND'
+        @output << 'position of '; node.args[0].accept(self)
+        @output << ' in '; node.args[1].accept(self)
+      when 'SUBSTITUTE'
+        node.args[0].accept(self)
+        @output << ' with '; node.args[1].accept(self)
+        @output << ' replaced by '; node.args[2].accept(self)
+      when 'CONCAT'    then humanize_concat(node.args)
+      when 'CONTAINS'
+        node.args[1].accept(self); @output << ' contains '; node.args[0].accept(self)
+      when 'MAP'       then humanize_enum(node, 'for each', 'in', ': ')
+      when 'FILTER'    then humanize_enum(node, 'filter', 'in', ' where ')
+      when 'ALL'       then humanize_enum(node, 'all', 'in', ' satisfy ')
+      when 'ANY'       then humanize_enum(node, 'any', 'in', ' satisfies ')
+      when 'PLUCK'     then humanize_pluck(node)
+      else
+        humanize_math(node) || super
+      end
+    end
+
+    def visit_case(node)
+      node.switch.accept(self)
+      @output << ' case:'
+      node.conditions.each { |c| c.accept(self) }
+      node.else&.accept(self)
+    end
+
+    def visit_switch(node)
+      node.node.accept(self)
+    end
+
+    def visit_case_conditional(node)
+      @output << ' when '
+      node.when.node.accept(self)
+      @output << ' then '
+      node.then.node.accept(self)
+    end
+
+    def visit_else(node)
+      @output << '; otherwise '
+      node.node.accept(self)
+    end
+
+    def visit_negation(node)
+      @output << 'negative '
+      node.node.accept(self)
+    end
+
+    def visit_nil(_node)
+      @output << 'null'
+    end
+
+    def visit_identifier(node)
+      if @values.key?(node.identifier)
+        value = @values[node.identifier]
+        @output << (value.is_a?(::String) ? value.inspect : value.to_s)
+      else
+        super
+      end
+    end
+
+    private
+
+    def humanize_if(node)
+      @output << 'if '
+      node.predicate.accept(self)
+      @output << ' then '
+      node.left.accept(self)
+      @output << ' else '
+      node.right.accept(self)
+    end
+
+    def humanize_join(args, conjunction)
+      args.each_with_index do |arg, i|
+        @output << " #{conjunction} " if i > 0
+        arg.accept(self)
+      end
+    end
+
+    def humanize_aggregate(args, prefix)
+      @output << prefix
+      args.each_with_index do |arg, i|
+        @output << (i == 0 ? ' ' : ', ')
+        arg.accept(self)
+      end
+    end
+
+    def humanize_round(node, word)
+      node.args[0].accept(self)
+      @output << " #{word} to "
+      node.args[1] ? node.args[1].accept(self) : (@output << '0')
+      @output << ' decimal places'
+    end
+
+    def humanize_concat(args)
+      args.each_with_index do |arg, i|
+        @output << (i == args.length - 1 && i > 0 ? ' and ' : ', ') if i > 0
+        arg.accept(self)
+      end
+      @output << ' joined'
+    end
+
+    def humanize_enum(node, verb, preposition, separator)
+      collection, item, expr = node.args
+      @output << "#{verb} "
+      item.accept(self)
+      @output << " #{preposition} "
+      collection.accept(self)
+      @output << separator
+      expr.accept(self)
+    end
+
+    def humanize_pluck(node)
+      @output << 'values of '
+      node.args[1].accept(self)
+      @output << ' from '
+      node.args[0].accept(self)
+      if node.args[2]
+        @output << ' (default: '; node.args[2].accept(self); @output << ')'
+      end
+    end
+
+    def humanize_switch(node)
+      args        = node.args
+      rest        = args[1..]
+      has_default = rest.length.odd?
+      pairs       = has_default ? rest[0..-2] : rest
+      pair_count  = pairs.length / 2
+
+      args[0].accept(self)
+      @output << ' switch:'
+      pairs.each_slice(2).with_index do |(match, result), idx|
+        @output << ' when '; match.accept(self)
+        @output << ' use ';  result.accept(self)
+        @output << ';' if has_default || idx < pair_count - 1
+      end
+      if has_default
+        @output << ' otherwise '; rest.last.accept(self)
+      end
+    end
+
+    def humanize_math(node)
+      style, phrase = MATH_PHRASES[node.name.to_s.upcase]
+      return nil unless phrase
+
+      case style
+      when :unary
+        @output << "#{phrase} "; node.args[0].accept(self)
+      when :binary_and
+        @output << "#{phrase} "
+        node.args[0].accept(self); @output << ' and '; node.args[1].accept(self)
+      when :binary_infix
+        node.args[0].accept(self); @output << " #{phrase} "; node.args[1].accept(self)
+      when :log
+        @output << "#{phrase} "
+        node.args[0].accept(self)
+        if node.args[1]
+          @output << ' in base '; node.args[1].accept(self)
+        end
+      end
+      true
+    end
+  end
+end

--- a/spec/humanize_visitor_spec.rb
+++ b/spec/humanize_visitor_spec.rb
@@ -1,0 +1,191 @@
+require 'spec_helper'
+require 'dentaku'
+require 'dentaku/humanize_visitor'
+
+describe Dentaku::HumanizeVisitor do
+  let(:calculator) { Dentaku::Calculator.new }
+
+  def humanize(expression, values = {})
+    described_class.new(calculator.ast(expression), values).to_s
+  end
+
+  it 'verbalizes comparison operators' do
+    expect(humanize('a >= 5')).to eq('a is greater than or equal to 5')
+    expect(humanize('a <= 5')).to eq('a is less than or equal to 5')
+    expect(humanize('a > 5')).to  eq('a is greater than 5')
+    expect(humanize('a < 5')).to  eq('a is less than 5')
+    expect(humanize('a = 5')).to  eq('a equals 5')
+    expect(humanize('a != 5')).to eq('a does not equal 5')
+  end
+
+  it 'verbalizes arithmetic operators' do
+    expect(humanize('1 + 2')).to eq('1 plus 2')
+    expect(humanize('3 - 1')).to eq('3 minus 1')
+    expect(humanize('2 * 3')).to eq('2 times 3')
+    expect(humanize('10 / 2')).to eq('10 divided by 2')
+    expect(humanize('2 ^ 3')).to eq('2 to the power of 3')
+    expect(humanize('7 % 3')).to eq('7 modulo 3')
+  end
+
+  it 'verbalizes bitwise operators' do
+    expect(humanize('1 & 2')).to  eq('1 bitwise and 2')
+    expect(humanize('1 | 2')).to  eq('1 bitwise or 2')
+    expect(humanize('1 << 2')).to eq('1 shifted left by 2')
+    expect(humanize('1 >> 2')).to eq('1 shifted right by 2')
+  end
+
+  it 'verbalizes logical combinators' do
+    expect(humanize('a >= 5 and a <= 10'))
+      .to eq('a is greater than or equal to 5 and a is less than or equal to 10')
+    expect(humanize('a < 0 or a > 100')).to eq('a is less than 0 or a is greater than 100')
+  end
+
+  it 'verbalizes negation' do
+    expect(humanize('-a')).to eq('negative a')
+  end
+
+  it 'verbalizes nil literal' do
+    expect(humanize('a = NULL')).to eq('a equals null')
+  end
+
+  it 'substitutes identifiers with provided values' do
+    expect(humanize('days >= min and days <= max', min: 5, max: 20))
+      .to eq('days is greater than or equal to 5 and days is less than or equal to 20')
+  end
+
+  it 'quotes string values in substitution' do
+    expect(humanize('name = expected', expected: 'Buk')).to eq('name equals "Buk"')
+  end
+
+  it 'preserves identifiers with no substitution value' do
+    expect(humanize('a + b', a: 1)).to eq('1 plus b')
+  end
+
+  it 'verbalizes IF' do
+    expect(humanize('IF(a > 0, "yes", "no")')).to eq('if a is greater than 0 then "yes" else "no"')
+  end
+
+  it 'verbalizes AND function' do
+    expect(humanize('AND(a > 0, b > 0)')).to eq('a is greater than 0 and b is greater than 0')
+  end
+
+  it 'verbalizes OR function' do
+    expect(humanize('OR(a > 0, b > 0)')).to eq('a is greater than 0 or b is greater than 0')
+  end
+
+  it 'verbalizes XOR' do
+    expect(humanize('XOR(a, b)')).to eq('a exclusive-or b')
+  end
+
+  it 'verbalizes NOT' do
+    expect(humanize('NOT(a)')).to eq('not a')
+  end
+
+  it 'verbalizes SWITCH with default' do
+    expect(humanize('SWITCH(x, 1, "one", 2, "two", "other")'))
+      .to eq('x switch: when 1 use "one"; when 2 use "two"; otherwise "other"')
+  end
+
+  it 'verbalizes SWITCH without default' do
+    expect(humanize('SWITCH(x, 1, "one", 2, "two")'))
+      .to eq('x switch: when 1 use "one"; when 2 use "two"')
+  end
+
+  it 'verbalizes MIN / MAX / SUM / AVG / COUNT' do
+    expect(humanize('MIN(a, b, c)')).to   eq('minimum of a, b, c')
+    expect(humanize('MAX(a, b)')).to      eq('maximum of a, b')
+    expect(humanize('SUM(a, b, c)')).to   eq('sum of a, b, c')
+    expect(humanize('AVG(a, b)')).to      eq('average of a, b')
+    expect(humanize('COUNT(a, b, c)')).to eq('count of a, b, c')
+  end
+
+  it 'verbalizes ABS' do
+    expect(humanize('ABS(x)')).to eq('absolute value of x')
+  end
+
+  it 'verbalizes ROUND / ROUNDUP / ROUNDDOWN' do
+    expect(humanize('ROUND(x, 2)')).to     eq('x rounded to 2 decimal places')
+    expect(humanize('ROUNDUP(x, 2)')).to   eq('x rounded up to 2 decimal places')
+    expect(humanize('ROUNDDOWN(x, 2)')).to eq('x rounded down to 2 decimal places')
+  end
+
+  it 'verbalizes INTERCEPT' do
+    expect(humanize('INTERCEPT(xs, ys)')).to eq('linear intercept of xs and ys')
+  end
+
+  it 'verbalizes LEFT / RIGHT' do
+    expect(humanize('LEFT(s, 3)')).to  eq('first 3 characters of s')
+    expect(humanize('RIGHT(s, 3)')).to eq('last 3 characters of s')
+  end
+
+  it 'verbalizes MID' do
+    expect(humanize('MID(s, 2, 4)')).to eq('4 characters of s starting at position 2')
+  end
+
+  it 'verbalizes LEN' do
+    expect(humanize('LEN(s)')).to eq('length of s')
+  end
+
+  it 'verbalizes FIND' do
+    expect(humanize('FIND(needle, haystack)')).to eq('position of needle in haystack')
+  end
+
+  it 'verbalizes SUBSTITUTE' do
+    expect(humanize('SUBSTITUTE(text, "foo", "bar")')).to eq('text with "foo" replaced by "bar"')
+  end
+
+  it 'verbalizes CONCAT' do
+    expect(humanize('CONCAT(a, b, c)')).to eq('a, b and c joined')
+  end
+
+  it 'verbalizes CONTAINS' do
+    expect(humanize('CONTAINS(needle, haystack)')).to eq('haystack contains needle')
+  end
+
+  it 'verbalizes CASE' do
+    expr = 'CASE x WHEN 1 THEN "one" WHEN 2 THEN "two" ELSE "other" END'
+    expect(humanize(expr)).to eq('x case: when 1 then "one" when 2 then "two"; otherwise "other"')
+  end
+
+  it 'verbalizes MAP' do
+    expect(humanize('MAP(items, x, x * 2)')).to eq('for each x in items: x times 2')
+  end
+
+  it 'verbalizes FILTER' do
+    expect(humanize('FILTER(items, x, x > 0)')).to eq('filter x in items where x is greater than 0')
+  end
+
+  it 'verbalizes ALL' do
+    expect(humanize('ALL(items, x, x > 0)')).to eq('all x in items satisfy x is greater than 0')
+  end
+
+  it 'verbalizes ANY' do
+    expect(humanize('ANY(items, x, x > 0)')).to eq('any x in items satisfies x is greater than 0')
+  end
+
+  it 'verbalizes PLUCK' do
+    expect(humanize('PLUCK(items, name)')).to eq('values of name from items')
+  end
+
+  it 'verbalizes unary Math functions' do
+    expect(humanize('SIN(x)')).to  eq('sine of x')
+    expect(humanize('COS(x)')).to  eq('cosine of x')
+    expect(humanize('TAN(x)')).to  eq('tangent of x')
+    expect(humanize('SQRT(x)')).to eq('square root of x')
+    expect(humanize('LOG(x)')).to  eq('logarithm of x')
+  end
+
+  it 'verbalizes LOG with base' do
+    expect(humanize('LOG(x, 10)')).to eq('logarithm of x in base 10')
+  end
+
+  it 'verbalizes binary Math functions' do
+    expect(humanize('ATAN2(y, x)')).to eq('arctangent of y and x')
+    expect(humanize('HYPOT(a, b)')).to eq('hypotenuse of a and b')
+  end
+
+  it 'is exposed via Calculator#humanize' do
+    result = calculator.humanize('days >= min and days <= max', min: 5, max: 20)
+    expect(result).to eq('days is greater than or equal to 5 and days is less than or equal to 20')
+  end
+end


### PR DESCRIPTION
## Why

Apps that expose Dentaku formulas to end users (HR tools, business-rule
engines, approval workflows) have no way to explain what a formula means
in plain language. This fills that gap.

```ruby
calc = Dentaku::Calculator.new

calc.humanize('IF(tenure >= 2, base * 1.1, base)')
# => "if tenure is greater than or equal to 2 then base times 1.1 else base"

calc.humanize('days >= min and days <= max', min: 5, max: 20)
# => "days is greater than or equal to 5 and days is less than or equal to 20"
```

## What

`HumanizeVisitor < PrintVisitor` — overrides only the output, inherits
everything else. Falls back to `PrintVisitor` for any unmapped node, so
custom functions still render.

Covers all built-in constructs: arithmetic, comparison, logical and
bitwise operators, `IF` / `SWITCH` / `CASE`, all numeric, string, and
collection functions, and the full Ruby `Math` module.

Lazy-loaded — no overhead unless `#humanize` is called.

## Notes

- Phrase wording (`"times"` vs `"multiplied by"`, etc.) is easy to adjust.
- i18n is out of scope but the phrase table is one hash — straightforward
  to externalize later if wanted.
- Happy to drop `Calculator#humanize` if you prefer the visitor standalone.


Happy to contribute and looking forward to any feedback or suggestions!
