### PR TITLE
Do not evaluate IF's predicate twice

### DIFF
--- a/lib/dentaku/ast/functions/if.rb
+++ b/lib/dentaku/ast/functions/if.rb
@@ -36,9 +36,7 @@ module Dentaku
       end
 
       def dependencies(context = {})
-        predicate.value(context) ? left.dependencies(context) : right.dependencies(context)
-      rescue Dentaku::Error, Dentaku::ArgumentError, Dentaku::ZeroDivisionError
-        args.flat_map { |arg| arg.dependencies(context) }.uniq
+        (predicate.dependencies(context) + left.dependencies(context) + right.dependencies(context)).uniq
       end
     end
   end

--- a/spec/ast/node_spec.rb
+++ b/spec/ast/node_spec.rb
@@ -21,10 +21,7 @@ describe Dentaku::AST::Node do
     expect(node.dependencies).to eq(['x', 'y', 'z'])
 
     node = make_node('if(x > 5, y, z)')
-    expect(node.dependencies('x' => 7)).to eq(['y'])
-
-    node = make_node('if(x > 5, y, z)')
-    expect(node.dependencies('x' => 2)).to eq(['z'])
+    expect(node.dependencies('x' => 7)).to eq(['y', 'z'])
 
     node = make_node('')
     expect(node.dependencies).to eq([])


### PR DESCRIPTION
### Problem:
with current "short-circuit" approach predicate value can be evaluated twice, which can lead to performance issues (in case when predicate is huge and complex), and also can lead to issues in code that depends on `dependencies` array (https://github.com/rubysolo/dentaku/issues/197)

for example doing some heavy operation inside of predicate (making DB call, net request or just doing huge amount of calculations)
```ruby
require "dentaku"
require "benchmark"

# simulate heavy predicate
heavy_func = ->(value) {
  puts "sleep for 0.5 sec"
  sleep(0.5)
  value
}

calculator = Dentaku::Calculator.new
calculator.add_function("heavy_func", :numeric, heavy_func)

time = Benchmark.measure do
  calculator.evaluate("IF(heavy_func(2) > 1, 42, 0)")
end
puts time.real
```
will result in
```
sleep for 0.5 sec
sleep for 0.5 sec
1.0005817290002597
```

or using some randomness `#dependencies` can return different values
```ruby
require "dentaku"

random_func = ->() { rand(1..10) }
calculator = Dentaku::Calculator.new
calculator.add_function("random", :numeric, random_func)

puts calculator.dependencies("IF(random() > 5, value_a, value_b)").inspect
```
will result in either
```
["value_a"]
``` 
or
```
["value_b"]
```

### Proposal
do not evaluate predicate at all and build dependencies for all args of IF each time