### PR TITLE
Improve operand type error messages in parser

### DIFF
--- a/lib/dentaku/exceptions.rb
+++ b/lib/dentaku/exceptions.rb
@@ -33,7 +33,8 @@ module Dentaku
   class ParseError < Error
     attr_reader :reason, :meta
 
-    def initialize(reason, **meta)
+    def initialize(reason, message = nil, **meta)
+      super(message || self.class.default_message(reason, meta))
       @reason = reason
       @meta = meta
     end
@@ -47,12 +48,62 @@ module Dentaku
       invalid_statement
     ].freeze
 
-    def self.for(reason, **meta)
+    def self.for(reason, message = nil, **meta)
       unless VALID_REASONS.include?(reason)
         raise ::ArgumentError, "Unhandled #{reason}"
       end
 
-      new(reason, **meta)
+      new(reason, message, **meta)
+    end
+
+    def self.default_message(reason, meta)
+      case reason
+      when :node_invalid
+        if meta.key?(:operator) && meta.key?(:expect) && meta.key?(:actual)
+          "#{meta.fetch(:operator)} requires #{expected_operand_description(meta.fetch(:expect))}, not #{formatted_actual(meta.fetch(:actual))}"
+        else
+          'Invalid node'
+        end
+      when :too_few_operands
+        "#{meta.fetch(:operator)} has too few operands (given #{meta.fetch(:actual)}, expected #{meta.fetch(:expect)})"
+      when :too_many_operands
+        "#{meta.fetch(:operator)} has too many operands (given #{meta.fetch(:actual)}, expected #{meta.fetch(:expect)})"
+      when :undefined_function
+        "Undefined function #{meta.fetch(:function_name)}"
+      when :unprocessed_token
+        "Unprocessed token #{meta.fetch(:token_name)}"
+      when :unknown_case_token
+        "Unknown case token #{meta.fetch(:token_name)}"
+      when :unbalanced_bracket
+        "Unbalanced bracket"
+      when :unbalanced_parenthesis
+        "Unbalanced parenthesis"
+      when :unknown_grouping_token
+        "Unknown grouping token #{meta.fetch(:token_name)}"
+      when :not_implemented_token_category
+        "Not implemented for tokens of category #{meta.fetch(:token_category)}"
+      when :invalid_statement
+        "Invalid statement"
+      else
+        raise ::ArgumentError, "Unhandled #{reason}"
+      end
+    end
+
+    def self.expected_operand_description(expectation)
+      expected = Array(expectation)
+      if expected.include?(:incompatible)
+        'operands that are numeric or compatible types'
+      elsif expected == [:numeric]
+        'numeric operands'
+      elsif expected == [:logical]
+        'logical operands'
+      else
+        "#{expected.join(', ')} operands"
+      end
+    end
+
+    def self.formatted_actual(actual)
+      actual.respond_to?(:to_sym) ? actual.to_sym : actual
     end
   end
 

--- a/lib/dentaku/exceptions.rb
+++ b/lib/dentaku/exceptions.rb
@@ -75,15 +75,15 @@ module Dentaku
       when :unknown_case_token
         "Unknown case token #{meta.fetch(:token_name)}"
       when :unbalanced_bracket
-        "Unbalanced bracket"
+        'Unbalanced bracket'
       when :unbalanced_parenthesis
-        "Unbalanced parenthesis"
+        'Unbalanced parenthesis'
       when :unknown_grouping_token
         "Unknown grouping token #{meta.fetch(:token_name)}"
       when :not_implemented_token_category
         "Not implemented for tokens of category #{meta.fetch(:token_category)}"
       when :invalid_statement
-        "Invalid statement"
+        'Invalid statement'
       else
         raise ::ArgumentError, "Unhandled #{reason}"
       end

--- a/lib/dentaku/parser.rb
+++ b/lib/dentaku/parser.rb
@@ -284,35 +284,7 @@ module Dentaku
     end
 
     def fail!(reason, **meta)
-      message =
-        case reason
-        when :node_invalid
-          "#{meta.fetch(:operator)} requires #{meta.fetch(:expect).join(', ')} operands, but got #{meta.fetch(:actual)}"
-        when :too_few_operands
-          "#{meta.fetch(:operator)} has too few operands (given #{meta.fetch(:actual)}, expected #{meta.fetch(:expect)})"
-        when :too_many_operands
-          "#{meta.fetch(:operator)} has too many operands (given #{meta.fetch(:actual)}, expected #{meta.fetch(:expect)})"
-        when :undefined_function
-          "Undefined function #{meta.fetch(:function_name)}"
-        when :unprocessed_token
-          "Unprocessed token #{meta.fetch(:token_name)}"
-        when :unknown_case_token
-          "Unknown case token #{meta.fetch(:token_name)}"
-        when :unbalanced_bracket
-          "Unbalanced bracket"
-        when :unbalanced_parenthesis
-          "Unbalanced parenthesis"
-        when :unknown_grouping_token
-          "Unknown grouping token #{meta.fetch(:token_name)}"
-        when :not_implemented_token_category
-          "Not implemented for tokens of category #{meta.fetch(:token_category)}"
-        when :invalid_statement
-          "Invalid statement"
-        else
-          raise ::ArgumentError, "Unhandled #{reason}"
-        end
-
-      raise ParseError.for(reason, **meta), message
+      raise ParseError.for(reason, **meta)
     end
   end
 end

--- a/spec/exceptions_spec.rb
+++ b/spec/exceptions_spec.rb
@@ -7,3 +7,104 @@ describe Dentaku::UnboundVariableError do
     expect(exception.unbound_variables).to include('length')
   end
 end
+
+describe Dentaku::ParseError do
+  describe '.for' do
+    it 'raises an ArgumentError for an unknown reason' do
+      expect {
+        described_class.for(:not_a_real_reason)
+      }.to raise_error(::ArgumentError, /Unhandled not_a_real_reason/)
+    end
+
+    it 'stores the reason and meta' do
+      error = described_class.for(:undefined_function, function_name: 'FOO')
+      expect(error.reason).to eq(:undefined_function)
+      expect(error.meta).to eq(function_name: 'FOO')
+    end
+
+    it 'uses a provided message instead of the default' do
+      error = described_class.for(:node_invalid, 'custom message')
+      expect(error.message).to eq('custom message')
+    end
+
+    it 'cannot be instantiated directly with new' do
+      expect {
+        described_class.new(:invalid_statement)
+      }.to raise_error(NoMethodError)
+    end
+  end
+
+  describe 'default messages' do
+    def message_for(reason, **meta)
+      described_class.for(reason, **meta).message
+    end
+
+    it 'describes incompatible operands for node_invalid' do
+      expect(message_for(:node_invalid, operator: 'Dentaku::AST::Addition', expect: :incompatible, actual: 'string'))
+        .to eq('Dentaku::AST::Addition requires operands that are numeric or compatible types, not string')
+    end
+
+    it 'describes numeric operands for node_invalid' do
+      expect(message_for(:node_invalid, operator: 'Op', expect: :numeric, actual: 'string'))
+        .to eq('Op requires numeric operands, not string')
+    end
+
+    it 'describes logical operands for node_invalid' do
+      expect(message_for(:node_invalid, operator: 'Op', expect: :logical, actual: 'numeric'))
+        .to eq('Op requires logical operands, not numeric')
+    end
+
+    it 'falls back to listing expectations for other node_invalid types' do
+      expect(message_for(:node_invalid, operator: 'Op', expect: [:datetime, :duration], actual: 'string'))
+        .to eq('Op requires datetime, duration operands, not string')
+    end
+
+    it 'uses a generic message when node_invalid meta is incomplete' do
+      expect(message_for(:node_invalid)).to eq('Invalid node')
+    end
+
+    it 'builds a too_few_operands message' do
+      expect(message_for(:too_few_operands, operator: 'IF', actual: 1, expect: 3))
+        .to eq('IF has too few operands (given 1, expected 3)')
+    end
+
+    it 'builds a too_many_operands message' do
+      expect(message_for(:too_many_operands, operator: 'IF', actual: 4, expect: 3))
+        .to eq('IF has too many operands (given 4, expected 3)')
+    end
+
+    it 'builds an undefined_function message' do
+      expect(message_for(:undefined_function, function_name: 'FOO'))
+        .to eq('Undefined function FOO')
+    end
+
+    it 'builds an unprocessed_token message' do
+      expect(message_for(:unprocessed_token, token_name: 'foo')).to eq('Unprocessed token foo')
+    end
+
+    it 'builds an unknown_case_token message' do
+      expect(message_for(:unknown_case_token, token_name: 'foo')).to eq('Unknown case token foo')
+    end
+
+    it 'builds an unbalanced_bracket message' do
+      expect(message_for(:unbalanced_bracket)).to eq('Unbalanced bracket')
+    end
+
+    it 'builds an unbalanced_parenthesis message' do
+      expect(message_for(:unbalanced_parenthesis)).to eq('Unbalanced parenthesis')
+    end
+
+    it 'builds an unknown_grouping_token message' do
+      expect(message_for(:unknown_grouping_token, token_name: 'foo')).to eq('Unknown grouping token foo')
+    end
+
+    it 'builds a not_implemented_token_category message' do
+      expect(message_for(:not_implemented_token_category, token_category: 'foo'))
+        .to eq('Not implemented for tokens of category foo')
+    end
+
+    it 'builds an invalid_statement message' do
+      expect(message_for(:invalid_statement)).to eq('Invalid statement')
+    end
+  end
+end

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -111,6 +111,15 @@ describe Dentaku::Parser do
       }.to raise_error(Dentaku::ParseError)
     end
 
+    it 'raises a parse error with clearer operand compatibility wording' do
+      expect {
+        parse('"hello" + 1')
+      }.to raise_error(
+        Dentaku::ParseError,
+        /requires operands that are numeric or compatible types, not string/
+      )
+    end
+
     it 'raises a parse error for too many operands' do
       expect {
         parse("IF(1, 0, IF(1, 2, 3, 4))")


### PR DESCRIPTION
Reworks the `:node_invalid` parse error wording so type-incompatibility errors read as natural English. Previously operations raised messages like:

    Dentaku::AST::Addition requires incompatible operands, but got string

which is misleading (it reads as if "incompatible operands" were required). Now they read:

    Dentaku::AST::Addition requires operands that are numeric or compatible types, not string