### PR TITLE
Added simplecov and move dev deps to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,5 +10,8 @@ group :development, :test do
   gem 'rake'
   gem 'rspec'
   gem 'rubocop'
-  gem 'simplecov', '~> 0.22'
+  # Stay on the 0.x line: simplecov 1.0 (2026-07) removed SimpleCov.running,
+  # which the RubyMine/IntelliJ coverage runner still relies on. Lift this
+  # once the IDE integration supports 1.0.
+  gem 'simplecov', '< 1.0'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,13 @@ source "http://rubygems.org"
 
 # Specify your gem's dependencies in dentaku.gemspec
 gemspec
+
+group :development, :test do
+  gem 'pry'
+  gem 'pry-byebug'
+  gem 'pry-stack_explorer'
+  gem 'rake'
+  gem 'rspec'
+  gem 'rubocop'
+  gem 'simplecov', '~> 0.22'
+end

--- a/dentaku.gemspec
+++ b/dentaku.gemspec
@@ -18,14 +18,6 @@ Gem::Specification.new do |s|
   s.add_dependency('concurrent-ruby')
   s.add_dependency('tsort')
 
-  s.add_development_dependency('pry')
-  s.add_development_dependency('pry-byebug')
-  s.add_development_dependency('pry-stack_explorer')
-  s.add_development_dependency('rake')
-  s.add_development_dependency('rspec')
-  s.add_development_dependency('rubocop')
-  s.add_development_dependency('simplecov')
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }


### PR DESCRIPTION
Pins `simplecov` to `~> 0.22` because simplecov 1.0.1 removed `SimpleCov.running`, which the RubyMine/IntelliJ coverage runner relies on, causing a `NameError` when running specs with coverage from the IDE.