### PR TITLE
anchor duration unit regexps to not match words containing units

### DIFF
--- a/lib/dentaku/ast/functions/duration.rb
+++ b/lib/dentaku/ast/functions/duration.rb
@@ -21,9 +21,9 @@ module Dentaku
 
         def validate_unit(unit)
           case unit.downcase
-          when /years?/ then :year
-          when /months?/ then :month
-          when /days?/ then :day
+          when /\Ayears?\z/ then :year
+          when /\Amonths?\z/ then :month
+          when /\Adays?\z/ then :day
           else
             raise Dentaku::ArgumentError.for(:incompatible_type, value: unit, for: Duration),
               "'#{unit || unit.class}' is not a valid duration unit"

--- a/spec/calculator_spec.rb
+++ b/spec/calculator_spec.rb
@@ -541,6 +541,14 @@ describe Dentaku::Calculator do
       expect(calculator.evaluate!('value2 - value', { value: value, value2: value2 })).to eq(value2 - value)
       expect(calculator.evaluate!('value - 7200', { value: value })).to eq(Time.local(2023, 7, 13, 8, 42, 11))
     end
+
+    it 'does not accept unknown durations' do
+      expect { calculator.evaluate!('duration(1, foo)') }.to raise_error(Dentaku::ArgumentError, /is not a valid duration unit/)
+      expect { calculator.evaluate!('duration(1, ay)') }.to raise_error(Dentaku::ArgumentError, /is not a valid duration unit/)
+      expect { calculator.evaluate!('duration(1, daysy)') }.to raise_error(Dentaku::ArgumentError, /is not a valid duration unit/)
+      expect { calculator.evaluate!('duration(1, ayear)') }.to raise_error(Dentaku::ArgumentError, /is not a valid duration unit/)
+      expect { calculator.evaluate!('duration(1, dayofmonthofyear)') }.to raise_error(Dentaku::ArgumentError, /is not a valid duration unit/)
+    end
   end
 
   describe 'functions' do


### PR DESCRIPTION
A fix to not allow `duration(1, somethingcontainingdays)`